### PR TITLE
Remove syntax-specific setting

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -8,6 +8,8 @@ extends: Packages/HTML/HTML.sublime-syntax
 
 file_extensions:
   - vue
+  - we
+  - wpy
 
 variables:
   # Embedded script and style syntaxes may be wrapped into html comments for

--- a/vue.sublime-settings
+++ b/vue.sublime-settings
@@ -1,8 +1,0 @@
-{
-	"extensions":
-	[
-		"vue",
-		"we",
-		"wpy"
-	]
-}


### PR DESCRIPTION
The removed settings file is not named correctly to have effect.

Assign its extensions via syntax definition.