### PR TITLE
Fix interpolation in CDATA

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -703,6 +703,11 @@ contexts:
     - meta_scope: meta.attribute-with-value.lang.html
     - include: immediately-pop
 
+  cdata-content:
+    - meta_prepend: true
+    - meta_include_prototype: false
+    - include: mustache-interpolations
+
   strings-common-content:
     - meta_prepend: true
     - include: mustache-interpolations

--- a/tests/syntax_tests_mustage.vue
+++ b/tests/syntax_tests_mustage.vue
@@ -144,4 +144,18 @@
 //                                           ^ meta.tag - meta.attribute-with-value
 //                                            ^ - meta.tag
 
+    <![CDATA[This is {{interpolated}} content.]]>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html
+//  ^^^ punctuation.definition.tag.begin.html
+//     ^^^^^ keyword.declaration.cdata.html
+//          ^ punctuation.definition.tag.begin.html
+//           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.html
+//           ^^^^^^^^ string.unquoted.cdata.html - meta.interpolation
+//                   ^^^^^^^^^^^^^^^^ meta.interpolation.vue - string
+//                   ^^ punctuation.section.interpolation.begin.html
+//                     ^^^^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
+//                                 ^^ punctuation.section.interpolation.end.html
+//                                   ^^^^^^^^^ string.unquoted.cdata.html - meta.interpolation
+//                                            ^^^ punctuation.definition.tag.end.html
+
 </html>


### PR DESCRIPTION
This commit ensures to clear string scope from interpolation within CDATA tags.