### PR TITLE
Remove Mustache from attribute values

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -693,10 +693,6 @@ contexts:
     - meta_prepend: true
     - meta_include_prototype: false
 
-  tag-attribute-value-content:
-    - meta_prepend: true
-    - include: mustache-interpolations
-
   tag-lang-attribute-meta:
     # required until ST4184 (PR #4061)
     - meta_include_prototype: false

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -1,5 +1,14 @@
 // SYNTAX TEST "Vue Component.sublime-syntax"
 
+    <!--
+    Text Interpolation
+
+    The most basic form of data binding is text interpolation
+    using the "Mustache" syntax (double curly braces):
+
+    see: https://vuejs.org/guide/essentials/template-syntax.html#text-interpolation
+     -->
+
     <h1> {{ foo.text }} </h1>
 //       ^^^^^^^^^^^^^^ meta.interpolation.vue
 //       ^^ punctuation.section.interpolation.begin.html
@@ -12,31 +21,111 @@
 //       ^^^^^^^^^^ source.js.embedded.vue
 //                 ^^ punctuation.section.interpolation.end.html
 
+    <!--
+    Mustache tags may only contain expressions!
+
+    see: https://vuejs.org/guide/essentials/template-syntax.html#expressions-only
+    -->
+
+    {{ number + 1 }}
+//  ^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^ punctuation.section.interpolation.begin.html
+//    ^^^^^^^^^^^^ source.js.embedded.vue
+//     ^^^^^^ variable.other.readwrite.js
+//            ^ keyword.operator.arithmetic.js
+//              ^ meta.number.integer.decimal.js constant.numeric.value.js
+//                ^^ punctuation.section.interpolation.end.html
+
+    {{ ok ? 'YES' : 'NO' }}
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^ punctuation.section.interpolation.begin.html
+//    ^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
+//     ^^ variable.other.readwrite.js
+//        ^ keyword.operator.ternary.js
+//          ^^^^^ meta.string.js string.quoted.single.js
+//          ^ punctuation.definition.string.begin.js
+//              ^ punctuation.definition.string.end.js
+//                ^ keyword.operator.ternary.js
+//                  ^^^^ meta.string.js string.quoted.single.js
+//                  ^ punctuation.definition.string.begin.js
+//                     ^ punctuation.definition.string.end.js
+//                       ^^ punctuation.section.interpolation.end.html
+
+    {{ message.split('').reverse().join('') }}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^ punctuation.section.interpolation.begin.html
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
+//     ^^^^^^^ variable.other.readwrite.js
+//            ^ punctuation.accessor.js
+//             ^^^^^ meta.function-call variable.function.js
+//                  ^^^^ meta.function-call meta.group.js
+//                  ^ punctuation.section.group.begin.js
+//                   ^^ meta.string.js string.quoted.single.js
+//                   ^ punctuation.definition.string.begin.js
+//                    ^ punctuation.definition.string.end.js
+//                     ^ punctuation.section.group.end.js
+//                      ^ punctuation.accessor.js
+//                       ^^^^^^^ meta.function-call variable.function.js
+//                              ^^ meta.function-call meta.group.js
+//                              ^ punctuation.section.group.begin.js
+//                               ^ punctuation.section.group.end.js
+//                                ^ punctuation.accessor.js
+//                                 ^^^^ meta.function-call variable.function.js
+//                                     ^^^^ meta.function-call meta.group.js
+//                                     ^ punctuation.section.group.begin.js
+//                                      ^^ meta.string.js string.quoted.single.js
+//                                      ^ punctuation.definition.string.begin.js
+//                                       ^ punctuation.definition.string.end.js
+//                                        ^ punctuation.section.group.end.js
+//                                          ^^ punctuation.section.interpolation.end.html
+
+    <div :id="`list-${id}`"></div>
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//           ^^^^^^^^^^^^^ meta.string.html
+//           ^ string.quoted.double.html punctuation.definition.string.begin.html - meta.interpolation
+//            ^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string string
+//                  ^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string meta.interpolation.js
+//                       ^ meta.interpolation.vue source.js.embedded.vue meta.string string
+//                        ^ string.quoted.double.html punctuation.definition.string.end.html - meta.interpolation
+
+    <!-- this is a statement, not an expression: -->
+    {{ var a = 1 }}
+//  ^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^ punctuation.section.interpolation.begin.html
+//    ^^^^^^^^^^^ source.js.embedded.vue
+//               ^^ punctuation.section.interpolation.end.html
+
+    <!-- flow control won't work either, use ternary expressions -->
+    {{ if (ok) { return message } }}
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^ punctuation.section.interpolation.begin.html
+//    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
+//                                ^^ punctuation.section.interpolation.end.html
+
+
+    <!--
+    Attribute Bindings
+
+    Mustaches cannot be used inside HTML attributes. Instead, use a v-bind directive:
+
+    see: https://vuejs.org/guide/essentials/template-syntax.html#attribute-bindings
+     -->
+
     <p attrib="{{ foo.value }}" >
-//            ^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
-//             ^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.vue
-//                            ^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
-//            ^ string.quoted.double.html punctuation.definition.string.begin.html
-//             ^^ punctuation.section.interpolation.begin.html - source.js
-//               ^^^^^^^^^^^ source.js.embedded.vue
-//                          ^^ punctuation.section.interpolation.end.html - source.js
-//                            ^ string.quoted.double.html punctuation.definition.string.end.html
+//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
 
     <p attrib='{{ foo.value }}' >
-//            ^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
-//             ^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.vue
-//                            ^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
-//            ^ string.quoted.single.html punctuation.definition.string.begin.html
-//             ^^ punctuation.section.interpolation.begin.html - source.js
-//               ^^^^^^^^^^^ source.js.embedded.vue
-//                          ^^ punctuation.section.interpolation.end.html - source.js
-//                            ^ string.quoted.single.html punctuation.definition.string.end.html
+//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
 
     <p attrib={{ foo.value }} >
-//            ^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html meta.interpolation.vue
-//            ^^ punctuation.section.interpolation.begin.html - source.js
-//              ^^^^^^^^^^^ source.js.embedded.vue
-//                         ^^ punctuation.section.interpolation.end.html - source.js
+//            ^^ meta.tag meta.attribute-with-value.html meta.string.html string.unquoted.html - meta.interpolation
+//               ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
+//                         ^^ meta.attribute-with-value.html entity.other.attribute-name.html
+
+
+    <!--
+    Vue Directives
+     -->
 
     <p v-attrib="{'key': 'value'}">
 //  ^^^ meta.tag - meta.attribute-with-value


### PR DESCRIPTION
Mustache text interpolation

1. is not supported within tag attribute values see: https://vuejs.org/guide/essentials/template-syntax.html#attribute-bindings

2. supports expressions only see: https://vuejs.org/guide/essentials/template-syntax.html#expressions-only

   Note, JavaScript provides an `expression` context, but embedding it causes `meta.interpolation` scope to be cleared, if mustache content is not a valid expression. Hence keeping `embed: scope:source.js` for now.

   A possible alternative context `expressions` requires ST4180+.