### PR TITLE
Refactor vue directives

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -53,6 +53,11 @@ variables:
     |   ^ (\s*) (-->) \s* $
     )
 
+  # safe directive end to ensure it is also html attribute end
+  vue_directive_break: (?![^{{ascii_space}}=/>:."'])
+  # safe vue directive name, parameter or modifier chars
+  vue_directive_char: '[A-Za-z0-9_-]'
+
 contexts:
 
 ###[ HTML TAGS ]##############################################################
@@ -735,21 +740,91 @@ contexts:
 ###[ VUE DIRECTIVES ]#########################################################
 
   vue-directive:
-    - match: (?=v-)
+    # https://vuejs.org/guide/essentials/list.html#list-rendering
+    - match: (?i:v-for){{vue_directive_break}}
+      scope: entity.other.attribute-name.html keyword.control.loop.for.vue
       push:
         - vue-directive-meta
         - vue-directive-assignment
-        - tag-generic-attribute-name
-    - match: (?::|@|#)
-      scope: punctuation.definition.attribute.html
+    # https://vuejs.org/guide/essentials/conditional.html#conditional-rendering
+    - match: (?i:v-if){{vue_directive_break}}
+      scope: entity.other.attribute-name.html keyword.control.conditional.if.vue
       push:
         - vue-directive-meta
         - vue-directive-assignment
-        - tag-generic-attribute-name
+    - match: (?i:v-else-if){{vue_directive_break}}
+      scope: entity.other.attribute-name.html keyword.control.conditional.elseif.vue
+      push:
+        - vue-directive-meta
+        - vue-directive-assignment
+    - match: (?i:v-else){{vue_directive_break}}
+      scope:
+        meta.attribute-with-value.directive.html
+        entity.other.attribute-name.html keyword.control.conditional.else.vue
+    - match: (?i:v-show){{vue_directive_break}}
+      scope: entity.other.attribute-name.html keyword.control.conditional.show.vue
+      push:
+        - vue-directive-meta
+        - vue-directive-assignment
+    # https://vuejs.org/guide/essentials/template-syntax.html#directives
+    - match: (?i:v-{{vue_directive_char}}+){{vue_directive_break}}
+      scope: keyword.control.directive.vue
+      push:
+        - vue-directive-meta
+        - vue-directive-assignment
+        - vue-directive-modifiers
+        - vue-directive-parameter
+    # `@event` is short hand form of `v-on:event`
+    # `:attr` is short hand form of `v-bind:attr`
+    # `#attr` is short hand form of `??`
+    - match: '[@:#]'
+      scope: keyword.control.directive.vue
+      push:
+        - vue-directive-meta
+        - vue-directive-assignment
+        - vue-directive-modifiers
+        - vue-directive-parameter-name
 
   vue-directive-meta:
     - meta_include_prototype: false
     - meta_scope: meta.attribute-with-value.directive.html
+    - include: immediately-pop
+
+  vue-directive-modifiers:
+    # https://vuejs.org/guide/essentials/event-handling.html#event-modifiers
+    - meta_scope: entity.other.attribute-name.html
+    - match: (\.)({{vue_directive_char}}+{{vue_directive_break}})?
+      captures:
+        1: punctuation.separator.vue
+        2: constant.other.vue
+    - include: immediately-pop
+
+  vue-directive-parameter:
+    # https://vuejs.org/guide/essentials/template-syntax.html#arguments
+    - match: ':'
+      scope: punctuation.separator.vue
+      set: vue-directive-parameter-name
+    - include: immediately-pop
+
+  vue-directive-parameter-name:
+    - meta_content_scope: variable.parameter.vue
+    - match: '{{vue_directive_break}}'
+      pop: 1
+    - match: (?=\[)
+      push: vue-dynamic-parameter-name
+    - match: '["''`<]'
+      scope: invalid.illegal.attribute-name.html
+
+  vue-dynamic-parameter-name:
+    # https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
+    - clear_scopes: 2  # clear `entity.other.attribute-name variable.parameter`
+    - match: \[
+      scope: meta.interpolation.vue punctuation.section.interpolation.begin.vue
+      embed: scope:source.js#expression-statement
+      embed_scope: meta.interpolation.vue source.js.embedded.vue
+      escape: \]
+      escape_captures:
+        0: meta.interpolation.vue punctuation.section.interpolation.end.vue
     - include: immediately-pop
 
   vue-directive-assignment:
@@ -776,20 +851,3 @@ contexts:
         0: meta.attribute-with-value.directive.html meta.string.html string.quoted.single.html
           punctuation.definition.string.end.html
     - include: else-pop
-
-  tag-generic-attribute-name:
-    - meta_prepend: true
-    # https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
-    - match: (?=\[)
-      push: vue-dynamic-attribute-name
-
-  vue-dynamic-attribute-name:
-    - clear_scopes: 1  # clear `entity.other.attribute-name`
-    - match: \[
-      scope: meta.interpolation.vue punctuation.section.interpolation.begin.vue
-      embed: scope:source.js#expression-statement
-      embed_scope: meta.interpolation.vue source.js.embedded.vue
-      escape: \]
-      escape_captures:
-        0: meta.interpolation.vue punctuation.section.interpolation.end.vue
-    - include: immediately-pop

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -1,0 +1,197 @@
+// SYNTAX TEST "Vue Component.sublime-syntax"
+
+<!--
+ Conditional Rendering
+
+ https://vuejs.org/guide/essentials/conditional.html#conditional-rendering
+ -->
+
+<div v-if="seen"></div>
+//^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^ entity.other.attribute-name.html keyword.control.conditional.if.vue
+//       ^ punctuation.separator.key-value.html
+//        ^^^^^^ meta.string.html
+//        ^ string.quoted.double.html punctuation.definition.string.begin.html
+//         ^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
+//             ^ string.quoted.double.html punctuation.definition.string.end.html
+
+<div v-else-if="maybe + seen"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^^^^^ entity.other.attribute-name.html keyword.control.conditional.elseif.vue
+//            ^ punctuation.separator.key-value.html
+//             ^^^^^^^^^^^^^^ meta.string.html
+//             ^ string.quoted.double.html punctuation.definition.string.begin.html
+//              ^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
+//              ^^^^^ variable.other.readwrite.js
+//                    ^ keyword.operator.arithmetic.js
+//                      ^^^^ variable.other.readwrite.js
+//                          ^ string.quoted.double.html punctuation.definition.string.end.html
+
+<div v-else></div>
+//^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^ meta.attribute-with-value.directive.html entity.other.attribute-name.html keyword.control.conditional.else.vue
+
+<div v-show="visible"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^^ entity.other.attribute-name.html keyword.control.conditional.show.vue
+//         ^ punctuation.separator.key-value.html
+//          ^^^^^^^^^ meta.string.html
+//          ^ string.quoted.double.html punctuation.definition.string.begin.html
+//           ^^^^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
+//                  ^ string.quoted.double.html punctuation.definition.string.end.html
+
+
+<!--
+ List Rendering
+
+ https://vuejs.org/guide/essentials/list.html#list-rendering
+ -->
+
+<li v-for="todo in todos"> {{ todo.name }} </li>
+//^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//  ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//  ^^^^^ entity.other.attribute-name.html keyword.control.loop.for.vue
+//       ^ punctuation.separator.key-value.html
+//        ^^^^^^^^^^^^^^^ meta.string.html
+//        ^ string.quoted.double.html punctuation.definition.string.begin.html
+//         ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
+//         ^^^^ variable.other.readwrite.js
+//              ^^ keyword.operator.js
+//                 ^^^^^ variable.other.readwrite.js
+//                      ^ string.quoted.double.html punctuation.definition.string.end.html
+//                       ^ punctuation.definition.tag.end.html
+//                         ^^^^^^^^^^^^^^^ meta.interpolation.vue
+//                         ^^ punctuation.section.interpolation.begin.html
+//                           ^^^^^^^^^^^ source.js.embedded.vue
+//                            ^^^^ variable.other.readwrite.js
+//                                ^ punctuation.accessor.js
+//                                 ^^^^ meta.property.object.js
+//                                      ^^ punctuation.section.interpolation.end.html
+//                                         ^^^^^ meta.tag
+
+
+<!--
+ Directive Arguments
+
+ https://vuejs.org/guide/essentials/template-syntax.html#arguments
+ -->
+
+<div v-on:event="doSomething()"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^^^^^^ entity.other.attribute-name.html - entity.other entity.other
+//   ^^^^ keyword.control.directive.vue
+//       ^ punctuation.separator.vue
+//        ^^^^^ variable.parameter.vue
+//             ^ punctuation.separator.key-value.html
+//              ^^^^^^^^^^^^^^^ meta.string.html
+//              ^ string.quoted.double.html punctuation.definition.string.begin.html
+//               ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                            ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+
+<div @event="doSomething()"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^^ entity.other.attribute-name.html - entity.other entity.other
+//   ^ keyword.control.directive.vue
+//    ^^^^^ variable.parameter.vue
+//         ^ punctuation.separator.key-value.html
+//          ^^^^^^^^^^^^^^^ meta.string.html
+//          ^ string.quoted.double.html punctuation.definition.string.begin.html
+//           ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                        ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+
+
+<!--
+ Dynamic Directive Arguments
+
+ https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
+ -->
+
+<div v-on:[eventName]="doSomething()"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^ entity.other.attribute-name.html
+//   ^^^^ keyword.control.directive.vue
+//       ^ punctuation.separator.vue
+//        ^^^^^^^^^^^ meta.interpolation.vue
+//        ^ punctuation.section.interpolation.begin.vue
+//         ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
+//                  ^ punctuation.section.interpolation.end.vue
+//                   ^ punctuation.separator.key-value.html
+//                    ^^^^^^^^^^^^^^^ meta.string.html
+//                    ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                     ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                                  ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+
+<div @[eventName]="doSomething()"></div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^ entity.other.attribute-name.html keyword.control.directive.vue
+//    ^^^^^^^^^^^ meta.interpolation.vue
+//    ^ punctuation.section.interpolation.begin.vue
+//     ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
+//              ^ punctuation.section.interpolation.end.vue
+//               ^ punctuation.separator.key-value.html
+//                ^^^^^^^^^^^^^^^ meta.string.html
+//                ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                 ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                              ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+
+
+<!--
+ Event Modifiers
+
+ https://vuejs.org/guide/essentials/event-handling.html#event-modifiers
+ -->
+
+<!-- the click event's propagation will be stopped -->
+<a v-on:click.stop="doThis()"></a>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+// ^^^^^^^^^^^^^^^ entity.other.attribute-name.html
+// ^^^^ keyword.control.directive.vue
+//     ^ punctuation.separator.vue
+//      ^^^^^ variable.parameter.vue
+//           ^ punctuation.separator.vue
+//            ^^^^ constant.other.vue
+//                ^ punctuation.separator.key-value.html
+//                 ^^^^^^^^^^ meta.string.html
+//                 ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                  ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                          ^ string.quoted.double.html punctuation.definition.string.end.html
+
+<!-- the click event's propagation will be stopped -->
+<a @click.stop="doThis()"></a>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+// ^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+// ^^^^^^^^^^^ entity.other.attribute-name.html
+// ^ keyword.control.directive.vue
+//  ^^^^^ variable.parameter.vue
+//       ^ punctuation.separator.vue
+//        ^^^^ constant.other.vue
+//            ^ punctuation.separator.key-value.html
+//             ^^^^^^^^^^ meta.string.html
+//             ^ string.quoted.double.html punctuation.definition.string.begin.html
+//              ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                      ^ string.quoted.double.html punctuation.definition.string.end.html
+
+<!-- modifiers can be chained -->
+<a @click.stop.prevent="doThat()"></a>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
+// ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
+// ^ keyword.control.directive.vue
+//  ^^^^^ variable.parameter.vue
+//       ^ punctuation.separator.vue
+//        ^^^^ constant.other.vue
+//            ^ punctuation.separator.vue
+//             ^^^^^^^ constant.other.vue
+//                    ^ punctuation.separator.key-value.html
+//                     ^^^^^^^^^^ meta.string.html
+//                     ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                      ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                              ^ string.quoted.double.html punctuation.definition.string.end.html

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -18,7 +18,7 @@
 
 <div v-else-if="maybe + seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^ meta.attribute-with-value.directive.html
+//   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
 //   ^^^^^^^^^ entity.other.attribute-name.html keyword.control.conditional.elseif.vue
 //            ^ punctuation.separator.key-value.html
 //             ^^^^^^^^^^^^^^ meta.string.html

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -65,30 +65,10 @@
 //                     ^ meta.tag - meta.attribute-with-value
 //                      ^ - meta.tag
 
-    <p @handler="function_call($event)">
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                                    ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                                     ^ meta.tag - meta.attribute-with-value
-//                                      ^ - meta.tag
-
-    <p @handler='function_call($event)'>
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                                    ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                                     ^ meta.tag - meta.attribute-with-value
-//                                      ^ - meta.tag
-
     <p #handler="variable">
 //  ^^^ meta.tag - meta.attribute-with-value
 //     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
+//     ^ keyword.control.directive.vue
 //              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
 //               ^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
 //                       ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
@@ -98,7 +78,7 @@
     <p #handler='variable'>
 //  ^^^ meta.tag - meta.attribute-with-value
 //     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
+//     ^ keyword.control.directive.vue
 //              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
 //               ^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
 //                       ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
@@ -108,7 +88,7 @@
     <p :handler="expression">
 //  ^^^ meta.tag - meta.attribute-with-value
 //     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
+//     ^ keyword.control.directive.vue
 //              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
 //               ^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
 //                         ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
@@ -118,7 +98,7 @@
     <p :handler='expression'>
 //  ^^^ meta.tag - meta.attribute-with-value
 //     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ punctuation.definition.attribute.html
+//     ^ keyword.control.directive.vue
 //              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
 //               ^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
 //                         ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
@@ -127,7 +107,7 @@
 
     <template #[`content-${variable}`]>
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html
-//            ^ entity.other.attribute-name.html
+//            ^ entity.other.attribute-name.html keyword.control.directive.vue
 //             ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
 //              ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue - entity.other.attribute-name.html
 //                                   ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
@@ -137,6 +117,7 @@
     <template v-slot:[`content-${variable}`] >
 //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html
 //            ^^^^^^^ entity.other.attribute-name.html
+//            ^^^^^^ keyword.control.directive.vue
 //                   ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
 //                    ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue - entity.other.attribute-name.html
 //                                         ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded


### PR DESCRIPTION
Resolves #4

This PR applies common scope scheme for vue directives: 

  `<keyword>:<param>.<modifier>.<modifier>="<expression>"`

All shorthand forms are also scoped this way resulting in `@`, `:`, `#` using `keyword.control.directive`.

Notes:

1. This is a probosal for a common starting point. It does not yet apply special scopes for `:ref`, but treats `:` as shorthand for `v-bind:` with `ref` as parameter.

2. The parameter/modifier parts are also borrowed and adjusted from Svelte.