### PR TITLE
CI: Adjust workflow to only run once

### DIFF
--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -3,16 +3,12 @@ name: CI Syntax Tests
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - '**'
+      - main
     paths:
       - '.github/workflows/ci-syntax-tests.yml'
       - '**.sublime-syntax'
       - '**/syntax_test_*'
   pull_request:
-    branches:
-      - main
     paths:
       - '.github/workflows/ci-syntax-tests.yml'
       - '**.sublime-syntax'


### PR DESCRIPTION
Pull requests have the highest priority and the `main` branch is primarily for regression testing. We'll also never create a PR *from* `main`.

Follow-up to #8.