### PR TITLE
Cleanup for ST4126+

### DIFF
--- a/.github/workflows/ci-syntax-tests.yml
+++ b/.github/workflows/ci-syntax-tests.yml
@@ -24,8 +24,6 @@ jobs:
       matrix:
         include:
           # Stable ST4 builds
-          - build: 4107
-            default_packages: v4107
           - build: 4126
             default_packages: v4126
           - build: 4143

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -12,41 +12,6 @@ file_extensions:
   - wpy
 
 variables:
-  # CSS specific variables
-  # ======================
-
-  # Embedded script and style syntaxes may be wrapped into html comments for
-  # historical reasons. The following patterns match them, while maintaining
-  # correct boundaries of embedded source scopes. That's required to enable
-  # embedded syntax's comment toggling in the first and last line.
-  #
-  # see:
-  # - https://github.com/sublimehq/Packages/issues/2322
-  # - https://github.com/sublimehq/sublime_text/issues/4701
-  script_content_begin: |-
-    (?x:
-    # whitespace followed by opening html comment begin punctuation
-      \s*(<!--)
-    # or any other non-whitespace character ahead
-    | (?=\s*(?!<!--)\S)
-    # or beginning of a line
-    | ^
-    )
-  script_content_end: |-
-    (?x:
-    # optional html comment end punctuation followed by </script> tag
-      (?: (\s*) (-->) \s* )? (?=</(?i:script){{tag_name_break_char}})
-    # or standalone html comment end punctuation in a line
-    |   ^ (\s*) (-->) \s* $
-    )
-  style_content_begin: '{{script_content_begin}}'
-  style_content_end: |-
-    (?x:
-    # optional html comment end punctuation followed by </style> tag
-      (?: (\s*) (-->) \s* )? (?=</(?i:style){{tag_name_break_char}})
-    # or standalone html comment end punctuation in a line
-    |   ^ (\s*) (-->) \s* $
-    )
 
   # Vue specific variables
   # ======================
@@ -69,29 +34,10 @@ contexts:
 
   tag-html:
     - meta_prepend: true
-    - include: script-tag
-    - include: style-tag
     - include: i18n-tag
     - include: template-tag
 
 ###[ SCRIPT TAG ]#############################################################
-
-  script-tag:
-    # required until ST4113
-    - match: (<)((?i:script)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push: script-javascript
-    - match: (</)((?i:script){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.script.html
-      push: script-close-tag-content
-
-  script-close-tag-content:
-    - meta_scope: meta.tag.script.end.html
-    - include: tag-end
 
   script-common:
     - meta_prepend: true
@@ -198,30 +144,6 @@ contexts:
         3: source.coffee.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
-  script-javascript:
-    # required until ST4113
-    - meta_scope: meta.tag.script.begin.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set: script-javascript-content
-    - include: script-common
-
-  script-javascript-content:
-    # required until ST4113
-    - meta_include_prototype: false
-    - match: '{{script_content_begin}}'
-      captures:
-        1: comment.block.html punctuation.definition.comment.begin.html
-      pop: 1  # make sure to match only once
-      embed: scope:source.js
-      embed_scope: source.js.embedded.html
-      escape: '{{script_content_end}}'
-      escape_captures:
-        1: source.js.embedded.html
-        2: comment.block.html punctuation.definition.comment.end.html
-        3: source.js.embedded.html
-        4: comment.block.html punctuation.definition.comment.end.html
-
   script-jsx:
     - meta_include_prototype: false
     - meta_scope: meta.tag.script.begin.html
@@ -316,23 +238,6 @@ contexts:
 
 ###[ STYLE TAG ]##############################################################
 
-  style-tag:
-    # required until ST4113
-    - match: (<)((?i:style)){{tag_name_break}}
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push: style-css
-    - match: (</)((?i:style){{tag_name_break}})
-      captures:
-        1: punctuation.definition.tag.begin.html
-        2: entity.name.tag.style.html
-      push: style-close-tag-content
-
-  style-close-tag-content:
-    - meta_scope: meta.tag.style.end.html
-    - include: tag-end
-
   style-common:
     - meta_prepend: true
     - include: style-lang-attribute
@@ -391,30 +296,6 @@ contexts:
         - style-css
         - tag-lang-attribute-meta
         - tag-generic-attribute-value
-
-  style-css:
-    # required until ST4113
-    - meta_scope: meta.tag.style.begin.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set: style-css-content
-    - include: style-common
-
-  style-css-content:
-    # required until ST4113
-    - meta_include_prototype: false
-    - match: '{{style_content_begin}}'
-      captures:
-        1: comment.block.html punctuation.definition.comment.begin.html
-      pop: 1  # make sure to match only once
-      embed: scope:source.css
-      embed_scope: source.css.embedded.html
-      escape: '{{style_content_end}}'
-      escape_captures:
-        1: source.css.embedded.html
-        2: comment.block.html punctuation.definition.comment.end.html
-        3: source.css.embedded.html
-        4: comment.block.html punctuation.definition.comment.end.html
 
   style-less:
     - meta_scope: meta.tag.style.begin.html
@@ -700,26 +581,6 @@ contexts:
   tag-attributes:
     - meta_prepend: true
     - include: vue-directive
-
-  tag-class-attribute-value:
-    # required until ST4113
-    - meta_prepend: true
-    - meta_include_prototype: false
-
-  tag-generic-attribute-value:
-    # required until ST4113
-    - meta_prepend: true
-    - meta_include_prototype: false
-
-  tag-href-attribute-value:
-    # required until ST4113
-    - meta_prepend: true
-    - meta_include_prototype: false
-
-  tag-id-attribute-value:
-    # required until ST4113
-    - meta_prepend: true
-    - meta_include_prototype: false
 
   tag-lang-attribute-meta:
     # required until ST4184 (PR #4061)


### PR DESCRIPTION
Resolves #9

Primary goal: Avoid duplicate `script` and `style` tag patterns in `tag-html` context.

It removes all contexts, which are present only for backward compatibility with ST4107..4113.