### PR TITLE
Add support for HAML templates

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -627,6 +627,11 @@ contexts:
     - include: template-lang-decider
 
   template-lang-decider:
+    - match: (?i)(?=haml{{unquoted_attribute_break}}|\'haml\'|"haml")
+      set:
+        - template-haml
+        - tag-lang-attribute-meta
+        - tag-generic-attribute-value
     - match: (?i)(?=jade{{unquoted_attribute_break}}|\'jade\'|"jade")
       set:
         - template-jade
@@ -647,6 +652,20 @@ contexts:
         - template-mustache
         - tag-lang-attribute-meta
         - tag-generic-attribute-value
+
+  template-haml:
+    - meta_scope: meta.tag.template.begin.html
+    - match: '>'
+      scope: punctuation.definition.tag.end.html
+      set: template-haml-content
+    - include: template-common
+
+  template-haml-content:
+    - match: '{{template_content_begin}}'
+      embed: scope:text.haml
+      embed_scope: text.haml.embedded.html
+      escape: '{{template_content_end}}'
+      pop: 1
 
   template-jade:
     - meta_scope: meta.tag.template.begin.html

--- a/tests/syntax_test_template.vue
+++ b/tests/syntax_test_template.vue
@@ -12,6 +12,31 @@
 // <- text.html.vue - text text
 //  ^^^^^^^^^^^ meta.tag.template.end.html
 
+    <!--
+    HAML Template Tests
+    -->
+
+    <template lang="haml">
+//  ^^^^^^^^^^ meta.tag - meta.tag meta.tag - meta.attribute-with-value
+//            ^^^^^^^^^^^ meta.tag meta.attribute-with-value.lang.html - meta.tag meta.tag
+//                       ^ meta.tag.template.begin.html - meta.tag meta.tag
+//  ^ punctuation.definition.tag.begin.html
+//   ^^^^^^^^ entity.name.tag.template.html
+//            ^^^^ entity.other.attribute-name.html
+//                ^ punctuation.separator.key-value.html
+//                       ^ punctuation.definition.tag.end.html
+
+// <- text.haml.embedded.html
+    </template>
+//  ^^^^^^^^^^^ meta.tag - meta.tag meta.tag - text.haml
+//  ^^ punctuation.definition.tag.begin.html
+//    ^^^^^^^^ entity.name.tag.template.html
+//            ^ punctuation.definition.tag.end.html
+
+    <!--
+    Jade Template Tests
+    -->
+
     <template lang="jade"> foo </template>
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.tag - source
 //                        ^^^^^ text.jade.embedded.html - meta.tag
@@ -31,7 +56,6 @@
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.tag - source
 //                        ^^^^^^^^^^^^^^ text.jade.embedded.html - meta.tag - comment
 //                                      ^^^^^^^^^^^ meta.tag - source
-
 
     <template lang="jade">
 
@@ -58,6 +82,10 @@
 //    ^^^^^^^^ entity.name.tag.template.html
 //            ^ punctuation.definition.tag.end.html
 
+    <!--
+    Pug Template Tests
+    -->
+
     <template lang="pug">
 //  ^^^^^^^^^^ meta.tag - meta.tag meta.tag - meta.attribute-with-value
 //            ^^^^^^^^^^ meta.tag meta.attribute-with-value.lang.html - meta.tag meta.tag
@@ -74,6 +102,10 @@
 //  ^^ punctuation.definition.tag.begin.html
 //    ^^^^^^^^ entity.name.tag.template.html
 //            ^ punctuation.definition.tag.end.html
+
+    <!--
+    Slim Template Tests
+    -->
 
     <template lang="slm">
 //  ^^^^^^^^^^ meta.tag - meta.tag meta.tag - meta.attribute-with-value


### PR DESCRIPTION
Resolves https://github.com/vuejs/vue-syntax-highlight/pull/202

This commit adds support for HAML syntax highlighting between `<template>` tags.