### PR TITLE
Fix nested quotes and brackets

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -863,7 +863,6 @@ contexts:
       set: vue-static-parameter-name
 
   vue-dynamic-parameter-name-end:
-    - clear_scopes: 1
     - meta_include_prototype: false
     - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
     - match: \]

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -771,11 +771,16 @@ contexts:
   mustache-templates:
     - match: '{{'
       scope: meta.interpolation.vue punctuation.section.interpolation.begin.html
-      embed: scope:source.js
-      embed_scope: meta.interpolation.vue source.js.embedded.vue
-      escape: '}}'
-      escape_captures:
-        0: meta.interpolation.vue punctuation.section.interpolation.end.html
+      push:
+        - mustache-template-end
+        - scope:source.js#expression
+
+  mustache-template-end:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - match: '}}'
+      scope: meta.interpolation.vue punctuation.section.interpolation.end.html
+      pop: 1
 
 ###[ VUE DIRECTIVES ]#########################################################
 
@@ -847,24 +852,29 @@ contexts:
     - include: immediately-pop
 
   vue-directive-parameter-name:
-    - match: '{{vue_parameter_break}}'
-      pop: 1
-    - match: (?=\[)
-      push: vue-dynamic-parameter-name
-    - match: '["''`<]'
-      scope: invalid.illegal.attribute-name.html
-
-  vue-dynamic-parameter-name:
+    - meta_include_prototype: false
     # https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
-    - clear_scopes: 1  # clear `entity.other.attribute-name
     - match: \[
       scope: meta.interpolation.vue punctuation.section.interpolation.begin.vue
-      embed: scope:source.js#expression-statement
-      embed_scope: meta.interpolation.vue source.js.embedded.vue
-      escape: \]
-      escape_captures:
-        0: meta.interpolation.vue punctuation.section.interpolation.end.vue
-    - include: immediately-pop
+      set:
+        - vue-dynamic-parameter-name-end
+        - scope:source.js#expression
+    - match: ''
+      set: vue-static-parameter-name
+
+  vue-dynamic-parameter-name-end:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - match: \]
+      scope: meta.interpolation.vue punctuation.section.interpolation.end.vue
+      pop: 1
+
+  vue-static-parameter-name:
+    - match: '{{vue_parameter_break}}'
+      pop: 1
+    - match: '["''`<]'
+      scope: invalid.illegal.attribute-name.html
 
   vue-directive-assignment:
     - match: =
@@ -875,18 +885,22 @@ contexts:
   vue-directive-value:
     - match: \"
       scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
-      embed: scope:source.js#expression-statement
-      embed_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
-      escape: \"
-      escape_captures:
-        0: meta.attribute-with-value.directive.html meta.string.html string.quoted.double.html
-          punctuation.definition.string.end.html
+      set:
+        - vue-directive-double-quoted-value-end
+        - scope:source.js#expression
     - match: \'
       scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-      embed: scope:source.js#expression-statement
-      embed_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
-      escape: \'
-      escape_captures:
-        0: meta.attribute-with-value.directive.html meta.string.html string.quoted.single.html
-          punctuation.definition.string.end.html
+      set:
+        - vue-directive-single-quoted-value-end
+        - scope:source.js#expression
     - include: else-pop
+
+  vue-directive-double-quoted-value-end:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
+    - include: strings-double-quoted-end
+
+  vue-directive-single-quoted-value-end:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
+    - include: strings-single-quoted-end

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -219,3 +219,39 @@
 //                        ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                         ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                                 ^ string.quoted.double.html punctuation.definition.string.end.html
+
+<!--
+ Nested brackets and quotes
+ -->
+
+<div
+    v-bind:[styles["name"]]='{
+//  ^^^^^^ keyword.other.directive.vue
+//        ^ punctuation.separator.vue
+//         ^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//         ^ punctuation.section.interpolation.begin.vue
+//          ^^^^^^ variable.other.readwrite.js
+//                ^^^^^^^^ meta.brackets.js
+//                ^ punctuation.section.brackets.begin.js
+//                 ^^^^^^ meta.string.js string.quoted.double.js
+//                       ^ punctuation.section.brackets.end.js
+//                        ^ punctuation.section.interpolation.end.vue
+//                         ^ punctuation.separator.key-value.html
+//                          ^ meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+//                           ^^ meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+        backgroundColor: active ? "green" : "red",
+//                              ^ keyword.operator.ternary.js
+//                                ^^^^^^^ meta.string.js string.quoted.double.js
+//                                        ^ keyword.operator.ternary.js
+//                                          ^^^^^ meta.string.js string.quoted.double.js
+        width: `'${width + "double" + 'single' + quoted}px'` // note the single quotes!
+//             ^^ meta.string string.quoted.other.js
+//               ^^^^^^^^^^ meta.string meta.interpolation.js - string
+//                         ^^^^^^^^ meta.interpolation.js string.quoted.double.js
+//                                 ^^^ meta.string meta.interpolation.js - string
+//                                    ^^^^^^^^ meta.interpolation.js string.quoted.single.js
+//                                            ^^^^^^^^^^ meta.string meta.interpolation.js - string
+//                                                      ^^^^ meta.string string.quoted.other.js
+    }'>
+//^^^ meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//   ^ meta.string.html string.quoted.single.html punctuation.definition.string.end.html

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -112,7 +112,7 @@
 <div v-on:[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^ entity.other.attribute-name.html
+//   ^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
 //   ^^^^ keyword.other.directive.vue
 //       ^ punctuation.separator.vue
 //        ^^^^^^^^^^^ meta.interpolation.vue
@@ -128,7 +128,8 @@
 <div @[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^ entity.other.attribute-name.html keyword.other.directive.vue
+//   ^^^^^^^^^^^^ entity.other.attribute-name.html
+//   ^ keyword.other.directive.vue
 //    ^^^^^^^^^^^ meta.interpolation.vue
 //    ^ punctuation.section.interpolation.begin.vue
 //     ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -195,20 +195,19 @@
 //                           ^ - meta.tag
 
     <template #[`content-${variable}`]>
-//            ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html
-//            ^ entity.other.attribute-name.html keyword.other.directive.vue
+//            ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html entity.other.attribute-name.html
+//            ^ keyword.other.directive.vue
 //             ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//              ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue - entity.other.attribute-name.html
+//              ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //                                   ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
 //                                    ^ meta.tag - meta.attribute-with-value
 //                                     ^ - meta.tag
 
     <template v-slot:[`content-${variable}`] >
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html
-//            ^^^^^^^ entity.other.attribute-name.html
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html entity.other.attribute-name.html
 //            ^^^^^^ keyword.other.directive.vue
 //                   ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//                    ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue - entity.other.attribute-name.html
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //                                         ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
 //                                          ^ meta.tag - meta.interpolation
 //                                           ^ meta.tag - meta.attribute-with-value


### PR DESCRIPTION
Resolves #28

This PR includes JavaScript expression instead of embedding it
in order to maintain context stack and enable nested quotes and brackets
without terminating script context too early.

This increases compiled syntax cache from 37kB to 170kB but it is still
within sane values.
