### PR TITLE
Tweak vue directive meta scopes

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -845,7 +845,7 @@ contexts:
     - match: '{{vue_parameter_break}}'
       set: vue-directive-modifiers
     - match: '["''`<]'
-      scope: invalid.illegal.attribute-name.html
+      scope: invalid.illegal.attribute-name.vue
 
   vue-directive-modifiers:
     # https://vuejs.org/guide/essentials/event-handling.html#event-modifiers
@@ -860,19 +860,19 @@ contexts:
   vue-directive-assignment:
     - meta_content_scope: meta.directive.vue
     - match: =
-      scope: meta.directive.vue punctuation.separator.key-value.html
+      scope: meta.directive.vue punctuation.separator.key-value.vue
       set: vue-directive-value
     - include: else-pop
 
   vue-directive-value:
     - meta_content_scope: meta.directive.vue
     - match: \"
-      scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
+      scope: string.quoted.double.vue punctuation.definition.string.begin.vue
       set:
         - vue-directive-double-quoted-value-end
         - scope:source.js#expression
     - match: \'
-      scope: meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+      scope: string.quoted.single.vue punctuation.definition.string.begin.vue
       set:
         - vue-directive-single-quoted-value-end
         - scope:source.js#expression
@@ -880,12 +880,16 @@ contexts:
 
   vue-directive-double-quoted-value-end:
     - meta_include_prototype: false
-    - meta_scope: meta.directive.value.vue
-    - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
-    - include: strings-double-quoted-end
+    - meta_scope: meta.directive.value.vue meta.string.vue
+    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - match: \"
+      scope: string.quoted.double.vue punctuation.definition.string.end.vue
+      pop: 1
 
   vue-directive-single-quoted-value-end:
     - meta_include_prototype: false
-    - meta_scope: meta.directive.value.vue
-    - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
-    - include: strings-single-quoted-end
+    - meta_scope: meta.directive.value.vue meta.string.vue
+    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - match: \'
+      scope: string.quoted.single.vue punctuation.definition.string.end.vue
+      pop: 1

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -787,75 +787,45 @@ contexts:
   vue-directive:
     # https://vuejs.org/guide/essentials/list.html#list-rendering
     - match: (?i:v-for){{vue_directive_break}}
-      scope: entity.other.attribute-name.html keyword.control.loop.for.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
+      scope: meta.directive.vue keyword.control.loop.for.vue
+      push: vue-directive-assignment
     # https://vuejs.org/guide/essentials/conditional.html#conditional-rendering
     - match: (?i:v-if){{vue_directive_break}}
-      scope: entity.other.attribute-name.html keyword.control.conditional.if.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
+      scope: meta.directive.vue keyword.control.conditional.if.vue
+      push: vue-directive-assignment
     - match: (?i:v-else-if){{vue_directive_break}}
-      scope: entity.other.attribute-name.html keyword.control.conditional.elseif.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
+      scope: meta.directive.vue keyword.control.conditional.elseif.vue
+      push: vue-directive-assignment
     - match: (?i:v-else){{vue_directive_break}}
-      scope:
-        meta.attribute-with-value.directive.html
-        entity.other.attribute-name.html keyword.control.conditional.else.vue
+      scope: meta.directive.vue keyword.control.conditional.else.vue
     - match: (?i:v-show){{vue_directive_break}}
-      scope: entity.other.attribute-name.html keyword.control.conditional.show.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
+      scope: meta.directive.vue keyword.control.conditional.show.vue
+      push: vue-directive-assignment
     # https://vuejs.org/guide/essentials/template-syntax.html#directives
     - match: (?i:v-{{vue_directive_char}}+){{vue_directive_break}}
-      scope: keyword.other.directive.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
-        - vue-directive-modifiers
-        - vue-directive-parameter
+      scope: meta.directive.vue keyword.other.directive.vue
+      push: vue-directive-parameter
     # `@event` is short hand form of `v-on:event`
     # `:attr` is short hand form of `v-bind:attr`
     # `#attr` is short hand form of `??`
     - match: '[@:#]'
-      scope: keyword.other.directive.vue
-      push:
-        - vue-directive-meta
-        - vue-directive-assignment
-        - vue-directive-modifiers
-        - vue-directive-parameter-name
-
-  vue-directive-meta:
-    - meta_include_prototype: false
-    - meta_scope: meta.attribute-with-value.directive.html
-    - include: immediately-pop
-
-  vue-directive-modifiers:
-    # https://vuejs.org/guide/essentials/event-handling.html#event-modifiers
-    - meta_scope: entity.other.attribute-name.html
-    - match: (\.)({{vue_directive_char}}+{{vue_directive_break}})?
-      captures:
-        1: punctuation.separator.vue
-        2: storage.modifier.vue
-    - include: immediately-pop
+      scope: meta.directive.vue keyword.other.directive.vue
+      push: vue-directive-parameter-name
 
   vue-directive-parameter:
+    - meta_include_prototype: false
     # https://vuejs.org/guide/essentials/template-syntax.html#arguments
     - match: ':'
-      scope: punctuation.separator.vue
+      scope: meta.directive.vue punctuation.separator.vue
       set: vue-directive-parameter-name
-    - include: immediately-pop
+    - match: ''
+      set: vue-directive-assignment
 
   vue-directive-parameter-name:
     - meta_include_prototype: false
     # https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
     - match: \[
-      scope: meta.interpolation.vue punctuation.section.interpolation.begin.vue
+      scope: punctuation.section.interpolation.begin.vue
       set:
         - vue-dynamic-parameter-name-end
         - scope:source.js#expression
@@ -864,24 +834,38 @@ contexts:
 
   vue-dynamic-parameter-name-end:
     - meta_include_prototype: false
-    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - meta_scope: meta.directive.parameter.vue meta.interpolation.vue
+    - meta_content_scope: source.js.embedded.vue
     - match: \]
-      scope: meta.interpolation.vue punctuation.section.interpolation.end.vue
-      pop: 1
+      scope: punctuation.section.interpolation.end.vue
+      set: vue-directive-modifiers
 
   vue-static-parameter-name:
+    - meta_scope: meta.directive.parameter.vue entity.other.attribute-name.vue
     - match: '{{vue_parameter_break}}'
-      pop: 1
+      set: vue-directive-modifiers
     - match: '["''`<]'
       scope: invalid.illegal.attribute-name.html
 
+  vue-directive-modifiers:
+    # https://vuejs.org/guide/essentials/event-handling.html#event-modifiers
+    - meta_content_scope: meta.directive.modifiers.vue
+    - match: (\.)({{vue_directive_char}}+{{vue_directive_break}})?
+      captures:
+        1: punctuation.separator.vue
+        2: storage.modifier.vue
+    - match: ''
+      set: vue-directive-assignment
+
   vue-directive-assignment:
+    - meta_content_scope: meta.directive.vue
     - match: =
-      scope: punctuation.separator.key-value.html
+      scope: meta.directive.vue punctuation.separator.key-value.html
       set: vue-directive-value
     - include: else-pop
 
   vue-directive-value:
+    - meta_content_scope: meta.directive.vue
     - match: \"
       scope: meta.string.html string.quoted.double.html punctuation.definition.string.begin.html
       set:
@@ -896,10 +880,12 @@ contexts:
 
   vue-directive-double-quoted-value-end:
     - meta_include_prototype: false
+    - meta_scope: meta.directive.value.vue
     - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
     - include: strings-double-quoted-end
 
   vue-directive-single-quoted-value-end:
     - meta_include_prototype: false
+    - meta_scope: meta.directive.value.vue
     - meta_content_scope: meta.string.html meta.interpolation.vue source.js.embedded.vue
     - include: strings-single-quoted-end

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -8,20 +8,18 @@
 
 <div v-if="seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^ entity.other.attribute-name.html keyword.control.conditional.if.vue
-//       ^ punctuation.separator.key-value.html
-//        ^^^^^^ meta.string.html
+//   ^^^^ meta.directive.vue keyword.control.conditional.if.vue
+//       ^ meta.directive.vue punctuation.separator.key-value.html
+//        ^^^^^^ meta.directive.value.vue meta.string.html
 //        ^ string.quoted.double.html punctuation.definition.string.begin.html
 //         ^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
 //             ^ string.quoted.double.html punctuation.definition.string.end.html
 
 <div v-else-if="maybe + seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^^^^ entity.other.attribute-name.html keyword.control.conditional.elseif.vue
-//            ^ punctuation.separator.key-value.html
-//             ^^^^^^^^^^^^^^ meta.string.html
+//   ^^^^^^^^^ meta.directive.vue keyword.control.conditional.elseif.vue
+//            ^ meta.directive.vue punctuation.separator.key-value.html
+//             ^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //             ^ string.quoted.double.html punctuation.definition.string.begin.html
 //              ^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //              ^^^^^ variable.other.readwrite.js
@@ -31,14 +29,13 @@
 
 <div v-else></div>
 //^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^ meta.attribute-with-value.directive.html entity.other.attribute-name.html keyword.control.conditional.else.vue
+//   ^^^^^^ meta.directive.vue keyword.control.conditional.else.vue
 
 <div v-show="visible"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^ entity.other.attribute-name.html keyword.control.conditional.show.vue
-//         ^ punctuation.separator.key-value.html
-//          ^^^^^^^^^ meta.string.html
+//   ^^^^^^ meta.directive.vue keyword.control.conditional.show.vue
+//         ^ meta.directive.vue punctuation.separator.key-value.html
+//          ^^^^^^^^^ meta.directive.value.vue meta.string.html
 //          ^ string.quoted.double.html punctuation.definition.string.begin.html
 //           ^^^^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
 //                  ^ string.quoted.double.html punctuation.definition.string.end.html
@@ -52,10 +49,9 @@
 
 <li v-for="todo in todos"> {{ todo.name }} </li>
 //^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//  ^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//  ^^^^^ entity.other.attribute-name.html keyword.control.loop.for.vue
-//       ^ punctuation.separator.key-value.html
-//        ^^^^^^^^^^^^^^^ meta.string.html
+//  ^^^^^ meta.directive.vue keyword.control.loop.for.vue
+//       ^ meta.directive.vue punctuation.separator.key-value.html
+//        ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //        ^ string.quoted.double.html punctuation.definition.string.begin.html
 //         ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //         ^^^^ variable.other.readwrite.js
@@ -81,23 +77,20 @@
 
 <div v-on:event="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^^^^^ entity.other.attribute-name.html - entity.other entity.other
-//   ^^^^ keyword.other.directive.vue
-//       ^ punctuation.separator.vue
-//             ^ punctuation.separator.key-value.html
-//              ^^^^^^^^^^^^^^^ meta.string.html
+//   ^^^^ meta.directive.vue keyword.other.directive.vue
+//       ^ meta.directive.vue punctuation.separator.vue
+//        ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
+//             ^ meta.directive.vue punctuation.separator.key-value.html
+//              ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //              ^ string.quoted.double.html punctuation.definition.string.begin.html
 //               ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                            ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
 
 <div @event="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^ entity.other.attribute-name.html - entity.other entity.other
-//   ^ keyword.other.directive.vue
-//         ^ punctuation.separator.key-value.html
-//          ^^^^^^^^^^^^^^^ meta.string.html
+//   ^ meta.directive.vue keyword.other.directive.vue
+//         ^ meta.directive.vue punctuation.separator.key-value.html
+//          ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //          ^ string.quoted.double.html punctuation.definition.string.begin.html
 //           ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                        ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
@@ -111,31 +104,27 @@
 
 <div v-on:[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
-//   ^^^^ keyword.other.directive.vue
-//       ^ punctuation.separator.vue
-//        ^^^^^^^^^^^ meta.interpolation.vue
+//   ^^^^ meta.directive.vue keyword.other.directive.vue
+//       ^ meta.directive.vue punctuation.separator.vue
+//        ^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
 //        ^ punctuation.section.interpolation.begin.vue
 //         ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
 //                  ^ punctuation.section.interpolation.end.vue
-//                   ^ punctuation.separator.key-value.html
-//                    ^^^^^^^^^^^^^^^ meta.string.html
+//                   ^ meta.directive.vue punctuation.separator.key-value.html
+//                    ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                    ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                     ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                                  ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
 
 <div @[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-//   ^^^^^^^^^^^^ entity.other.attribute-name.html
-//   ^ keyword.other.directive.vue
-//    ^^^^^^^^^^^ meta.interpolation.vue
+//   ^ meta.directive.vue keyword.other.directive.vue
+//    ^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
 //    ^ punctuation.section.interpolation.begin.vue
 //     ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
 //              ^ punctuation.section.interpolation.end.vue
-//               ^ punctuation.separator.key-value.html
-//                ^^^^^^^^^^^^^^^ meta.string.html
+//               ^ meta.directive.vue punctuation.separator.key-value.html
+//                ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                 ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                              ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
@@ -150,14 +139,13 @@
 <!-- the click event's propagation will be stopped -->
 <a v-on:click.stop="doThis()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-// ^^^^^^^^^^^^^^^ entity.other.attribute-name.html
-// ^^^^ keyword.other.directive.vue
-//     ^ punctuation.separator.vue
-//           ^ punctuation.separator.vue
-//            ^^^^ storage.modifier.vue
-//                ^ punctuation.separator.key-value.html
-//                 ^^^^^^^^^^ meta.string.html
+// ^^^^ meta.directive.vue keyword.other.directive.vue
+//     ^ meta.directive.vue punctuation.separator.vue
+//      ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
+//           ^ meta.directive.modifiers.vue punctuation.separator.vue
+//            ^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//                ^ meta.directive.vue punctuation.separator.key-value.html
+//                 ^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                 ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                  ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                          ^ string.quoted.double.html punctuation.definition.string.end.html
@@ -165,13 +153,12 @@
 <!-- the click event's propagation will be stopped -->
 <a @click.stop="doThis()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-// ^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-// ^^^^^^^^^^^ entity.other.attribute-name.html
-// ^ keyword.other.directive.vue
-//       ^ punctuation.separator.vue
-//        ^^^^ storage.modifier.vue
-//            ^ punctuation.separator.key-value.html
-//             ^^^^^^^^^^ meta.string.html
+// ^ meta.directive.vue keyword.other.directive.vue
+//  ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
+//       ^ meta.directive.modifiers.vue punctuation.separator.vue
+//        ^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//            ^ meta.directive.vue punctuation.separator.key-value.html
+//             ^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //             ^ string.quoted.double.html punctuation.definition.string.begin.html
 //              ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                      ^ string.quoted.double.html punctuation.definition.string.end.html
@@ -179,44 +166,41 @@
 <!-- modifiers can be chained -->
 <a @click.stop.prevent="doThat()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-// ^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
-// ^ keyword.other.directive.vue
-//       ^ punctuation.separator.vue
-//        ^^^^ storage.modifier.vue
-//            ^ punctuation.separator.vue
-//             ^^^^^^^ storage.modifier.vue
-//                    ^ punctuation.separator.key-value.html
-//                     ^^^^^^^^^^ meta.string.html
+// ^ meta.directive.vue keyword.other.directive.vue
+//  ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
+//       ^ meta.directive.modifiers.vue punctuation.separator.vue
+//        ^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//            ^ meta.directive.modifiers.vue punctuation.separator.vue
+//             ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//                    ^ meta.directive.vue punctuation.separator.key-value.html
+//                     ^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                     ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                      ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                              ^ string.quoted.double.html punctuation.definition.string.end.html
 
 <a v-on:click:outside.prevent="doThis()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
-// ^^^^ keyword.other.directive.vue
-//     ^ punctuation.separator.vue
+// ^^^^ meta.directive.vue keyword.other.directive.vue
+//     ^ meta.directive.vue  punctuation.separator.vue
+//      ^^^^^^^^^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
 //           ^ - punctuation
-//                   ^ punctuation.separator.vue
-//                    ^^^^^^^ storage.modifier.vue
-//                           ^ punctuation.separator.key-value.html
-//                            ^^^^^^^^^^ meta.string.html
+//                   ^ meta.directive.modifiers.vue punctuation.separator.vue
+//                    ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//                           ^ meta.directive.vue punctuation.separator.key-value.html
+//                            ^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                            ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                             ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                                     ^ string.quoted.double.html punctuation.definition.string.end.html
 
 <a @click:outside.prevent="doThat()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.attribute-with-value.directive.html
-// ^^^^^^^^^^^^^^^^^^^^^^ entity.other.attribute-name.html
-// ^ keyword.other.directive.vue
+// ^ meta.directive.vue keyword.other.directive.vue
+//  ^^^^^^^^^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
 //       ^ - punctuation
-//               ^ punctuation.separator.vue
-//                ^^^^^^^ storage.modifier.vue
-//                       ^ punctuation.separator.key-value.html
-//                        ^^^^^^^^^^ meta.string.html
+//               ^ meta.directive.modifiers.vue punctuation.separator.vue
+//                ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
+//                       ^ meta.directive.vue punctuation.separator.key-value.html
+//                        ^^^^^^^^^^ meta.directive.value.vue meta.string.html
 //                        ^ string.quoted.double.html punctuation.definition.string.begin.html
 //                         ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
 //                                 ^ string.quoted.double.html punctuation.definition.string.end.html
@@ -227,9 +211,9 @@
 
 <div
     v-bind:[styles["name"]]='{
-//  ^^^^^^ keyword.other.directive.vue
-//        ^ punctuation.separator.vue
-//         ^^^^^^^^^^^^^^^^ meta.interpolation.vue
+//  ^^^^^^ meta.directive.vue keyword.other.directive.vue
+//        ^ meta.directive.vue punctuation.separator.vue
+//         ^^^^^^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
 //         ^ punctuation.section.interpolation.begin.vue
 //          ^^^^^^ variable.other.readwrite.js
 //                ^^^^^^^^ meta.brackets.js
@@ -237,9 +221,9 @@
 //                 ^^^^^^ meta.string.js string.quoted.double.js
 //                       ^ punctuation.section.brackets.end.js
 //                        ^ punctuation.section.interpolation.end.vue
-//                         ^ punctuation.separator.key-value.html
-//                          ^ meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-//                           ^^ meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//                         ^ meta.directive.vue punctuation.separator.key-value.html
+//                          ^ meta.directive.value.vue meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
+//                           ^^ meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
         backgroundColor: active ? "green" : "red",
 //                              ^ keyword.operator.ternary.js
 //                                ^^^^^^^ meta.string.js string.quoted.double.js
@@ -254,5 +238,94 @@
 //                                            ^^^^^^^^^^ meta.string meta.interpolation.js - string
 //                                                      ^^^^ meta.string string.quoted.other.js
     }'>
-//^^^ meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
-//   ^ meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+//^^^ meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//   ^ meta.directive.value.vue meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+
+    <!--
+    Other Vue Directives
+     -->
+
+    <p v-attrib="{'key': 'value'}">
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping
+//                               ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                                ^ meta.tag - meta.directive
+//                                 ^ - meta.tag
+
+    <p v-attrib="i = 0">
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                     ^ meta.tag - meta.directive
+//                      ^ - meta.tag
+
+    <p v-attrib='i = 0'>
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                     ^ meta.tag - meta.directive
+//                      ^ - meta.tag
+
+    <p #handler="variable">
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                        ^ meta.tag - meta.directive
+//                         ^ - meta.tag
+
+    <p #handler='variable'>
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                        ^ meta.tag - meta.directive
+//                         ^ - meta.tag
+
+    <p :handler="expression">
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                          ^ meta.tag - meta.directive
+//                           ^ - meta.tag
+
+    <p :handler='expression'>
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                          ^ meta.tag - meta.directive
+//                           ^ - meta.tag
+
+    <template #[`content-${variable}`]>
+//            ^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
+//             ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
+//              ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
+//                                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//                                    ^ meta.tag.template.begin.html - meta.directive
+//                                     ^ - meta.tag
+
+    <template v-slot:[`content-${variable}`] >
+//            ^^^^^^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
+//                  ^ meta.tag.template.begin.html meta.directive.vue punctuation.separator.vue
+//                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
+//                                         ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//                                          ^ meta.tag.template.begin.html meta.directive.vue
+//                                           ^ meta.tag.template.begin.html - meta.directive
+//                                            ^ - meta.tag

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -9,23 +9,23 @@
 <div v-if="seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^ meta.directive.vue keyword.control.conditional.if.vue
-//       ^ meta.directive.vue punctuation.separator.key-value.html
-//        ^^^^^^ meta.directive.value.vue meta.string.html
-//        ^ string.quoted.double.html punctuation.definition.string.begin.html
+//       ^ meta.directive.vue punctuation.separator.key-value.vue
+//        ^^^^^^ meta.directive.value.vue meta.string.vue
+//        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //         ^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
-//             ^ string.quoted.double.html punctuation.definition.string.end.html
+//             ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div v-else-if="maybe + seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^^^^^^ meta.directive.vue keyword.control.conditional.elseif.vue
-//            ^ meta.directive.vue punctuation.separator.key-value.html
-//             ^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//             ^ string.quoted.double.html punctuation.definition.string.begin.html
+//            ^ meta.directive.vue punctuation.separator.key-value.vue
+//             ^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//             ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //              ^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //              ^^^^^ variable.other.readwrite.js
 //                    ^ keyword.operator.arithmetic.js
 //                      ^^^^ variable.other.readwrite.js
-//                          ^ string.quoted.double.html punctuation.definition.string.end.html
+//                          ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div v-else></div>
 //^^^^^^^^^^^^^^^^ meta.tag
@@ -34,11 +34,11 @@
 <div v-show="visible"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^^^ meta.directive.vue keyword.control.conditional.show.vue
-//         ^ meta.directive.vue punctuation.separator.key-value.html
-//          ^^^^^^^^^ meta.directive.value.vue meta.string.html
-//          ^ string.quoted.double.html punctuation.definition.string.begin.html
+//         ^ meta.directive.vue punctuation.separator.key-value.vue
+//          ^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//          ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //           ^^^^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
-//                  ^ string.quoted.double.html punctuation.definition.string.end.html
+//                  ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 
 <!--
@@ -50,14 +50,14 @@
 <li v-for="todo in todos"> {{ todo.name }} </li>
 //^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //  ^^^^^ meta.directive.vue keyword.control.loop.for.vue
-//       ^ meta.directive.vue punctuation.separator.key-value.html
-//        ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//        ^ string.quoted.double.html punctuation.definition.string.begin.html
+//       ^ meta.directive.vue punctuation.separator.key-value.vue
+//        ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //         ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
 //         ^^^^ variable.other.readwrite.js
 //              ^^ keyword.operator.js
 //                 ^^^^^ variable.other.readwrite.js
-//                      ^ string.quoted.double.html punctuation.definition.string.end.html
+//                      ^ string.quoted.double.vue punctuation.definition.string.end.vue
 //                       ^ punctuation.definition.tag.end.html
 //                         ^^^^^^^^^^^^^^^ meta.interpolation.vue
 //                         ^^ punctuation.section.interpolation.begin.html
@@ -80,20 +80,20 @@
 //   ^^^^ meta.directive.vue keyword.other.directive.vue
 //       ^ meta.directive.vue punctuation.separator.vue
 //        ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
-//             ^ meta.directive.vue punctuation.separator.key-value.html
-//              ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//              ^ string.quoted.double.html punctuation.definition.string.begin.html
+//             ^ meta.directive.vue punctuation.separator.key-value.vue
+//              ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//              ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //               ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                            ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+//                            ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div @event="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^ meta.directive.vue keyword.other.directive.vue
-//         ^ meta.directive.vue punctuation.separator.key-value.html
-//          ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//          ^ string.quoted.double.html punctuation.definition.string.begin.html
+//         ^ meta.directive.vue punctuation.separator.key-value.vue
+//          ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//          ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //           ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                        ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+//                        ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 
 <!--
@@ -110,11 +110,11 @@
 //        ^ punctuation.section.interpolation.begin.vue
 //         ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
 //                  ^ punctuation.section.interpolation.end.vue
-//                   ^ meta.directive.vue punctuation.separator.key-value.html
-//                    ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                    ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                   ^ meta.directive.vue punctuation.separator.key-value.vue
+//                    ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                    ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                     ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                                  ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+//                                  ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div @[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
@@ -123,11 +123,11 @@
 //    ^ punctuation.section.interpolation.begin.vue
 //     ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
 //              ^ punctuation.section.interpolation.end.vue
-//               ^ meta.directive.vue punctuation.separator.key-value.html
-//                ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                ^ string.quoted.double.html punctuation.definition.string.begin.html
+//               ^ meta.directive.vue punctuation.separator.key-value.vue
+//                ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                 ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                              ^ meta.string.html string.quoted.double.html punctuation.definition.string.end.html
+//                              ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 
 <!--
@@ -144,11 +144,11 @@
 //      ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
 //           ^ meta.directive.modifiers.vue punctuation.separator.vue
 //            ^^^^ meta.directive.modifiers.vue storage.modifier.vue
-//                ^ meta.directive.vue punctuation.separator.key-value.html
-//                 ^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                 ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                ^ meta.directive.vue punctuation.separator.key-value.vue
+//                 ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                 ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                  ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                          ^ string.quoted.double.html punctuation.definition.string.end.html
+//                          ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!-- the click event's propagation will be stopped -->
 <a @click.stop="doThis()"></a>
@@ -157,11 +157,11 @@
 //  ^^^^^ meta.directive.parameter.vue entity.other.attribute-name.vue
 //       ^ meta.directive.modifiers.vue punctuation.separator.vue
 //        ^^^^ meta.directive.modifiers.vue storage.modifier.vue
-//            ^ meta.directive.vue punctuation.separator.key-value.html
-//             ^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//             ^ string.quoted.double.html punctuation.definition.string.begin.html
+//            ^ meta.directive.vue punctuation.separator.key-value.vue
+//             ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//             ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //              ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                      ^ string.quoted.double.html punctuation.definition.string.end.html
+//                      ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!-- modifiers can be chained -->
 <a @click.stop.prevent="doThat()"></a>
@@ -172,11 +172,11 @@
 //        ^^^^ meta.directive.modifiers.vue storage.modifier.vue
 //            ^ meta.directive.modifiers.vue punctuation.separator.vue
 //             ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
-//                    ^ meta.directive.vue punctuation.separator.key-value.html
-//                     ^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                     ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                    ^ meta.directive.vue punctuation.separator.key-value.vue
+//                     ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                     ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                      ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                              ^ string.quoted.double.html punctuation.definition.string.end.html
+//                              ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <a v-on:click:outside.prevent="doThis()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
@@ -186,11 +186,11 @@
 //           ^ - punctuation
 //                   ^ meta.directive.modifiers.vue punctuation.separator.vue
 //                    ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
-//                           ^ meta.directive.vue punctuation.separator.key-value.html
-//                            ^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                            ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                           ^ meta.directive.vue punctuation.separator.key-value.vue
+//                            ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                            ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                             ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                                     ^ string.quoted.double.html punctuation.definition.string.end.html
+//                                     ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <a @click:outside.prevent="doThat()"></a>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
@@ -199,11 +199,11 @@
 //       ^ - punctuation
 //               ^ meta.directive.modifiers.vue punctuation.separator.vue
 //                ^^^^^^^ meta.directive.modifiers.vue storage.modifier.vue
-//                       ^ meta.directive.vue punctuation.separator.key-value.html
-//                        ^^^^^^^^^^ meta.directive.value.vue meta.string.html
-//                        ^ string.quoted.double.html punctuation.definition.string.begin.html
+//                       ^ meta.directive.vue punctuation.separator.key-value.vue
+//                        ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
+//                        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
 //                         ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
-//                                 ^ string.quoted.double.html punctuation.definition.string.end.html
+//                                 ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!--
  Nested brackets and quotes
@@ -221,9 +221,9 @@
 //                 ^^^^^^ meta.string.js string.quoted.double.js
 //                       ^ punctuation.section.brackets.end.js
 //                        ^ punctuation.section.interpolation.end.vue
-//                         ^ meta.directive.vue punctuation.separator.key-value.html
-//                          ^ meta.directive.value.vue meta.string.html string.quoted.single.html punctuation.definition.string.begin.html
-//                           ^^ meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//                         ^ meta.directive.vue punctuation.separator.key-value.vue
+//                          ^ meta.directive.value.vue meta.string.vue string.quoted.single.vue punctuation.definition.string.begin.vue
+//                           ^^ meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping.js
         backgroundColor: active ? "green" : "red",
 //                              ^ keyword.operator.ternary.js
 //                                ^^^^^^^ meta.string.js string.quoted.double.js
@@ -238,8 +238,8 @@
 //                                            ^^^^^^^^^^ meta.string meta.interpolation.js - string
 //                                                      ^^^^ meta.string string.quoted.other.js
     }'>
-//^^^ meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping.js
-//   ^ meta.directive.value.vue meta.string.html string.quoted.single.html punctuation.definition.string.end.html
+//^^^ meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//   ^ meta.directive.value.vue meta.string.vue string.quoted.single.vue punctuation.definition.string.end.vue
 
     <!--
     Other Vue Directives
@@ -248,27 +248,27 @@
     <p v-attrib="{'key': 'value'}">
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping
-//                               ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping
+//                               ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                                ^ meta.tag - meta.directive
 //                                 ^ - meta.tag
 
     <p v-attrib="i = 0">
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
     <p v-attrib='i = 0'>
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
@@ -276,9 +276,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
@@ -286,9 +286,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
@@ -296,9 +296,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 
@@ -306,9 +306,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
 //                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -81,12 +81,12 @@
 
     <div :id="`list-${id}`"></div>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
-//           ^^^^^^^^^^^^^ meta.string.html
-//           ^ string.quoted.double.html punctuation.definition.string.begin.html - meta.interpolation
+//           ^^^^^^^^^^^^^ meta.string.vue
+//           ^ string.quoted.double.vue punctuation.definition.string.begin.vue - meta.interpolation
 //            ^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string string
 //                  ^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string meta.interpolation.js
 //                       ^ meta.interpolation.vue source.js.embedded.vue meta.string string
-//                        ^ string.quoted.double.html punctuation.definition.string.end.html - meta.interpolation
+//                        ^ string.quoted.double.vue punctuation.definition.string.end.vue - meta.interpolation
 
     <!-- this is a statement, not an expression: -->
     {{ var a = 1 }}
@@ -121,96 +121,6 @@
 //            ^^ meta.tag meta.attribute-with-value.html meta.string.html string.unquoted.html - meta.interpolation
 //               ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
 //                         ^^ meta.attribute-with-value.html entity.other.attribute-name.html
-
-
-    <!--
-    Vue Directives
-     -->
-
-    <p v-attrib="{'key': 'value'}">
-//  ^^^ meta.tag - meta.directive
-//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping
-//                               ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                                ^ meta.tag - meta.directive
-//                                 ^ - meta.tag
-
-    <p v-attrib="i = 0">
-//  ^^^ meta.tag - meta.directive
-//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                     ^ meta.tag - meta.directive
-//                      ^ - meta.tag
-
-    <p v-attrib='i = 0'>
-//  ^^^ meta.tag - meta.directive
-//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                     ^ meta.tag - meta.directive
-//                      ^ - meta.tag
-
-    <p #handler="variable">
-//  ^^^ meta.tag - meta.directive
-//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
-//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                        ^ meta.tag - meta.directive
-//                         ^ - meta.tag
-
-    <p #handler='variable'>
-//  ^^^ meta.tag - meta.directive
-//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
-//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                        ^ meta.tag - meta.directive
-//                         ^ - meta.tag
-
-    <p :handler="expression">
-//  ^^^ meta.tag - meta.directive
-//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
-//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                          ^ meta.tag - meta.directive
-//                           ^ - meta.tag
-
-    <p :handler='expression'>
-//  ^^^ meta.tag - meta.directive
-//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
-//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
-//                          ^ meta.tag - meta.directive
-//                           ^ - meta.tag
-
-    <template #[`content-${variable}`]>
-//            ^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
-//             ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//              ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
-//                                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
-//                                    ^ meta.tag.template.begin.html - meta.directive
-//                                     ^ - meta.tag
-
-    <template v-slot:[`content-${variable}`] >
-//            ^^^^^^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
-//                  ^ meta.tag.template.begin.html meta.directive.vue punctuation.separator.vue
-//                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//                    ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
-//                                         ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
-//                                          ^ meta.tag.template.begin.html meta.directive.vue
-//                                           ^ meta.tag.template.begin.html - meta.directive
-//                                            ^ - meta.tag
 
     <![CDATA[This is {{interpolated}} content.]]>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag.sgml.cdata.html

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -128,89 +128,88 @@
      -->
 
     <p v-attrib="{'key': 'value'}">
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping
-//                               ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                                ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue meta.mapping
+//                               ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                                ^ meta.tag - meta.directive
 //                                 ^ - meta.tag
 
     <p v-attrib="i = 0">
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                     ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
     <p v-attrib='i = 0'>
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                     ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
     <p #handler="variable">
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ keyword.other.directive.vue
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                        ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
     <p #handler='variable'>
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ keyword.other.directive.vue
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                        ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
     <p :handler="expression">
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ keyword.other.directive.vue
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                          ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 
     <p :handler='expression'>
-//  ^^^ meta.tag - meta.attribute-with-value
-//     ^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html - meta.string
-//     ^ keyword.other.directive.vue
-//              ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html meta.string.html meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.attribute-with-value.directive.html meta.string.html - meta.interpolation
-//                          ^ meta.tag - meta.attribute-with-value
+//  ^^^ meta.tag - meta.directive
+//     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
+//      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
+//              ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.html meta.interpolation.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.html - meta.interpolation
+//                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 
     <template #[`content-${variable}`]>
-//            ^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html entity.other.attribute-name.html
-//            ^ keyword.other.directive.vue
-//             ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//              ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
-//                                   ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
-//                                    ^ meta.tag - meta.attribute-with-value
+//            ^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
+//             ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
+//              ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
+//                                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//                                    ^ meta.tag.template.begin.html - meta.directive
 //                                     ^ - meta.tag
 
     <template v-slot:[`content-${variable}`] >
-//            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.directive.html entity.other.attribute-name.html
-//            ^^^^^^ keyword.other.directive.vue
-//                   ^ meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//                    ^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
-//                                         ^ meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
-//                                          ^ meta.tag - meta.interpolation
-//                                           ^ meta.tag - meta.attribute-with-value
+//            ^^^^^^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
+//                  ^ meta.tag.template.begin.html meta.directive.vue punctuation.separator.vue
+//                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
+//                                         ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//                                          ^ meta.tag.template.begin.html meta.directive.vue
+//                                           ^ meta.tag.template.begin.html - meta.directive
 //                                            ^ - meta.tag
 
     <![CDATA[This is {{interpolated}} content.]]>


### PR DESCRIPTION
This PR...

1. replaces HTML like `meta.attribute-with-value` by dedicated `meta.directive.[parameter|modifier|value].vue` scope to provide unique names for each part of them.
2. Removes stacking entity.other and keyword scopes to reduce overall scope name complexity/length.