### PR TITLE
Use JSX as default script language

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -128,11 +128,6 @@ contexts:
         - script-coffeescript
         - tag-lang-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=jsx{{unquoted_attribute_break}}|'jsx'|"jsx")
-      set:
-        - script-jsx
-        - tag-lang-attribute-meta
-        - tag-generic-attribute-value
     - match: (?i)(?=livescript{{unquoted_attribute_break}}|'livescript'|"livescript")
       set:
         - script-livescript
@@ -200,39 +195,10 @@ contexts:
         3: source.coffee.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
-  script-javascript:
-    # required until ST4113
-    - meta_scope: meta.tag.script.begin.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set: script-javascript-content
-    - include: script-common
-
   script-javascript-content:
-    # required until ST4113
-    - meta_include_prototype: false
-    - match: '{{script_content_begin}}'
-      captures:
-        1: comment.block.html punctuation.definition.comment.begin.html
-      pop: 1  # make sure to match only once
-      embed: scope:source.js
-      embed_scope: source.js.embedded.html
-      escape: '{{script_content_end}}'
-      escape_captures:
-        1: source.js.embedded.html
-        2: comment.block.html punctuation.definition.comment.end.html
-        3: source.js.embedded.html
-        4: comment.block.html punctuation.definition.comment.end.html
-
-  script-jsx:
-    - meta_include_prototype: false
-    - meta_scope: meta.tag.script.begin.html
-    - match: '>'
-      scope: punctuation.definition.tag.end.html
-      set: script-jsx-content
-    - include: script-common
-
-  script-jsx-content:
+    # Note: Augment default JavaScript by JSX
+    # as Vue supports writing components via JSX tags by default
+    # and JSX highlights/scopes plain JavaScript without issues.
     - meta_include_prototype: false
     - match: '{{script_content_begin}}'
       captures:

--- a/tests/syntax_test_script.vue
+++ b/tests/syntax_test_script.vue
@@ -5,12 +5,12 @@
 
     <script> var i = 0; </script>
 //  ^^^^^^^^ meta.tag - source
-//          ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+//          ^^^^^^^^^^^^ source.jsx.embedded.html - meta.tag
 //                      ^^^^^^^^^ meta.tag - source
 
     <script> var i = 0; --> </script>
 //  ^^^^^^^^ meta.tag - source
-//          ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+//          ^^^^^^^^^^^^ source.jsx.embedded.html - meta.tag
 //                      ^^^^ - meta.tag - source
 //                      ^^^ comment.block.html punctuation.definition.comment.end.html
 //                          ^^^^^^^^^ meta.tag - source
@@ -18,7 +18,7 @@
     <script> <!-- var i = 0; </script>
 //  ^^^^^^^^ meta.tag - source
 //          ^^^^^ - meta.tag - source
-//               ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+//               ^^^^^^^^^^^^ source.jsx.embedded.html - meta.tag
 //                           ^^^^^^^^^ meta.tag - source
 //           ^^^^ punctuation.definition.comment.begin.html
 
@@ -26,7 +26,7 @@
 //  ^^^^^^^^ meta.tag - source
 //          ^^^^^ - meta.tag - source
 //           ^^^^ punctuation.definition.comment.begin.html
-//               ^^^^^^^^^^^^ source.js.embedded.html - meta.tag
+//               ^^^^^^^^^^^^ source.jsx.embedded.html - meta.tag
 //                           ^^^^ - meta.tag - source
 //                           ^^^ comment.block.html punctuation.definition.comment.end.html
 //                               ^^^^^^^^^ meta.tag - source
@@ -34,9 +34,33 @@
 
     <script>
 
-// <- source.js.embedded.html
+// <- source.jsx.embedded.html
     var i = 0;
-// ^^^^^^^^^^^^ source.js.embedded.html - source source
+// ^^^^^^^^^^^^ source.jsx.embedded.html - source source
+    export default {
+      render () {
+        return <div>{ this.foo }</div>
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.jsx.embedded.html
+//      ^^^^^^ keyword.control.flow.return.js
+//             ^^^^^^^^^^^^^^^^^^^^^^^ meta.jsx.js
+//             ^^^^^ meta.tag
+//             ^ punctuation.definition.tag.begin.js
+//              ^^^ entity.name.tag
+//                 ^ punctuation.definition.tag.end.js
+//                  ^^^^^^^^^^^^ meta.interpolation.js
+//                  ^ punctuation.definition.interpolation.begin.js
+//                   ^^^^^^^^^^ source.js.embedded.jsx
+//                             ^ punctuation.definition.interpolation.end.js
+//                              ^^^^^^ meta.tag
+//                              ^^ punctuation.definition.tag.begin.js
+//                                ^^^ entity.name.tag
+//                                   ^ punctuation.definition.tag.end.js
+      }
+//^^^^^^ source.jsx.embedded.html
+//    ^ punctuation.section
+    }
+//^^^^ source.jsx.embedded.html
+//  ^ punctuation.section
     </script>
 //  ^^^^^^^^^ meta.tag - source
 
@@ -46,7 +70,7 @@
 //^^^^^^ - meta.tag - source
 //  ^^^^ comment.block.html punctuation.definition.comment.begin.html
     var i = 0;
-// ^^^^^^^^^^^^ source.js.embedded.html - source source - meta.tag
+// ^^^^^^^^^^^^ source.jsx.embedded.html - source source - meta.tag
     -->
 //  ^^^ comment.block.html punctuation.definition.comment.end.html - source
 //     ^ - comment - source
@@ -66,10 +90,10 @@
 //           ^^^^ comment.block.html punctuation.definition.comment.begin.html
 
     var foo = 100;
-// <- source.js.embedded.html - source source
+// <- source.jsx.embedded.html - source source
 
     (a --> b);
-//     ^^^ source.js.embedded.html keyword.operator - comment
+//     ^^^ source.jsx.embedded.html keyword.operator - comment
 
     --> </script>
 //  ^^^ comment.block.html punctuation.definition.comment.end.html - source
@@ -92,10 +116,10 @@
 //                                  ^^^^ comment.block.html punctuation.definition.comment.begin.html
 
     var foo = 100;
-// <- source.js.embedded.html - source source
+// <- source.jsx.embedded.html - source source
 
     (a --> b);
-//     ^^^ source.js.embedded.html keyword.operator - comment
+//     ^^^ source.jsx.embedded.html keyword.operator - comment
 
     --> </script>
 //  ^^^ comment.block.html punctuation.definition.comment.end.html - source
@@ -113,8 +137,8 @@
     application/jAvAsCrIpT>
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value - meta.attribute-with-value meta.attribute-with-value
     var foo = 100;
-// <- source.js.embedded.html - source source
-// ^^^^^^^^^^^^^^^^ source.js.embedded.html - source source
+// <- source.jsx.embedded.html - source source
+// ^^^^^^^^^^^^^^^^ source.jsx.embedded.html - source source
     </script>
 //  ^^^^^^^^^ meta.tag - source
 


### PR DESCRIPTION
This commit applies JSX as default syntax for `<script>` tags to avoid users bothering with trying to do so.

Vue supports writing components with JSX syntax and thus it may appear in normal template script tags. As JSX is fully compatible with normal JavaScript syntax let's use JSX as default syntax.