### PR TITLE
Fix js interpolated string termination

### DIFF
--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -834,28 +834,28 @@ contexts:
     - meta_content_scope: meta.directive.vue
     - match: \"
       scope: string.quoted.double.vue punctuation.definition.string.begin.vue
-      set:
-        - vue-directive-double-quoted-value-end
-        - scope:source.js#expression
+      set: vue-directive-double-quoted-value
     - match: \'
       scope: string.quoted.single.vue punctuation.definition.string.begin.vue
-      set:
-        - vue-directive-single-quoted-value-end
-        - scope:source.js#expression
+      set: vue-directive-single-quoted-value
     - include: else-pop
 
-  vue-directive-double-quoted-value-end:
+  vue-directive-double-quoted-value:
     - meta_include_prototype: false
     - meta_scope: meta.directive.value.vue meta.string.vue
     - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
     - match: \"
       scope: string.quoted.double.vue punctuation.definition.string.end.vue
       pop: 1
+    - match: (?=\S)
+      push: scope:source.js#expression
 
-  vue-directive-single-quoted-value-end:
+  vue-directive-single-quoted-value:
     - meta_include_prototype: false
     - meta_scope: meta.directive.value.vue meta.string.vue
     - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
     - match: \'
       scope: string.quoted.single.vue punctuation.definition.string.end.vue
       pop: 1
+    - match: (?=\S)
+      push: scope:source.js#expression

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -6,6 +6,24 @@
  https://vuejs.org/guide/essentials/conditional.html#conditional-rendering
  -->
 
+<div v-if=''></div>
+//^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^ meta.directive.vue keyword.control.conditional.if.vue
+//       ^ meta.directive.vue punctuation.separator.key-value.vue
+//        ^^ meta.directive.value.vue meta.string.vue
+//        ^ string.quoted.single.vue punctuation.definition.string.begin.vue
+//         ^ string.quoted.single.vue punctuation.definition.string.end.vue
+//          ^ punctuation.definition.tag.end.html
+
+<div v-if=""></div>
+//^^^^^^^^^^^^^^^^^ meta.tag
+//   ^^^^ meta.directive.vue keyword.control.conditional.if.vue
+//       ^ meta.directive.vue punctuation.separator.key-value.vue
+//        ^^ meta.directive.value.vue meta.string.vue
+//        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
+//         ^ string.quoted.double.vue punctuation.definition.string.end.vue
+//          ^ punctuation.definition.tag.end.html
+
 <div v-if="seen"></div>
 //^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^ meta.directive.vue keyword.control.conditional.if.vue


### PR DESCRIPTION
This commit adds dedicated embedded JS syntax definitions for single and double quoted attribute values to ensure both,
1. correctly terminating attribute values on given quotation mark found in top-level expression instead of pushing into a JS string context.
2. maintain nested quotation highlighting

Note: primary trigger were empty directive values not being derminated.