### PR TITLE
Align mustache tag scope with other languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+# MacOS specific ignores
 .DS_Store
+
+# development
+.sublime/
+.venv/
+.vscode/
+
+# python cache files
+__pycache__/
+*.pyc

--- a/Vue Component.sublime-syntax
+++ b/Vue Component.sublime-syntax
@@ -67,7 +67,7 @@ contexts:
 
   prototype:
     - meta_prepend: true
-    - include: mustache-templates
+    - include: mustache-interpolations
 
   tag-html:
     - meta_prepend: true
@@ -717,36 +717,38 @@ contexts:
   cdata-content:
     - meta_prepend: true
     - meta_include_prototype: false
-    - include: mustache-interpolations
+    - include: mustache-string-interpolations
 
   strings-common-content:
     - meta_prepend: true
-    - include: mustache-interpolations
+    - include: mustache-string-interpolations
 
 ###[ MUSTAGE TEMPLATES ]######################################################
 
-  mustache-interpolations:
-    - match: (?={{)
-      push: mustache-interpolation-content
-
-  mustache-interpolation-content:
-    - clear_scopes: 1
-    - include: mustache-templates
-    - include: immediately-pop
-
-  mustache-templates:
+  mustache-string-interpolations:
     - match: '{{'
-      scope: meta.interpolation.vue punctuation.section.interpolation.begin.html
-      push:
-        - mustache-template-end
-        - scope:source.js#expression
+      scope: meta.embedded.expression.vue punctuation.section.embedded.begin.html
+      push: mustache-string-interpolation-body
 
-  mustache-template-end:
+  mustache-string-interpolation-body:
+    - clear_scopes: 1
     - meta_include_prototype: false
-    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - meta_content_scope: meta.embedded.expression.vue source.js.embedded.vue
+    - include: mustache-interpolation-body
+
+  mustache-interpolations:
+    - match: '{{'
+      scope: meta.embedded.expression.vue punctuation.section.embedded.begin.html
+      push: mustache-interpolation-body
+
+  mustache-interpolation-body:
+    - meta_include_prototype: false
+    - meta_content_scope: meta.embedded.expression.vue source.js.embedded.vue
     - match: '}}'
-      scope: meta.interpolation.vue punctuation.section.interpolation.end.html
+      scope: meta.embedded.expression.vue punctuation.section.embedded.end.html
       pop: 1
+    - match: (?=\S)
+      push: scope:source.js#expression
 
 ###[ VUE DIRECTIVES ]#########################################################
 
@@ -791,7 +793,7 @@ contexts:
     - meta_include_prototype: false
     # https://vuejs.org/guide/essentials/template-syntax.html#dynamic-arguments
     - match: \[
-      scope: punctuation.section.interpolation.begin.vue
+      scope: punctuation.section.embedded.begin.vue
       set:
         - vue-dynamic-parameter-name-end
         - scope:source.js#expression
@@ -800,10 +802,10 @@ contexts:
 
   vue-dynamic-parameter-name-end:
     - meta_include_prototype: false
-    - meta_scope: meta.directive.parameter.vue meta.interpolation.vue
+    - meta_scope: meta.directive.parameter.vue meta.embedded.expression.vue
     - meta_content_scope: source.js.embedded.vue
     - match: \]
-      scope: punctuation.section.interpolation.end.vue
+      scope: punctuation.section.embedded.end.vue
       set: vue-directive-modifiers
 
   vue-static-parameter-name:
@@ -843,7 +845,7 @@ contexts:
   vue-directive-double-quoted-value:
     - meta_include_prototype: false
     - meta_scope: meta.directive.value.vue meta.string.vue
-    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - meta_content_scope: meta.embedded.expression.vue source.js.embedded.vue
     - match: \"
       scope: string.quoted.double.vue punctuation.definition.string.end.vue
       pop: 1
@@ -853,7 +855,7 @@ contexts:
   vue-directive-single-quoted-value:
     - meta_include_prototype: false
     - meta_scope: meta.directive.value.vue meta.string.vue
-    - meta_content_scope: meta.interpolation.vue source.js.embedded.vue
+    - meta_content_scope: meta.embedded.expression.vue source.js.embedded.vue
     - match: \'
       scope: string.quoted.single.vue punctuation.definition.string.end.vue
       pop: 1

--- a/tests/syntax_test_directive.vue
+++ b/tests/syntax_test_directive.vue
@@ -30,7 +30,7 @@
 //       ^ meta.directive.vue punctuation.separator.key-value.vue
 //        ^^^^^^ meta.directive.value.vue meta.string.vue
 //        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//         ^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
+//         ^^^^ meta.embedded.expression.vue source.js.embedded.vue variable.other.readwrite.js
 //             ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div v-else-if="maybe + seen"></div>
@@ -39,7 +39,7 @@
 //            ^ meta.directive.vue punctuation.separator.key-value.vue
 //             ^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //             ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//              ^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
+//              ^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue
 //              ^^^^^ variable.other.readwrite.js
 //                    ^ keyword.operator.arithmetic.js
 //                      ^^^^ variable.other.readwrite.js
@@ -55,7 +55,7 @@
 //         ^ meta.directive.vue punctuation.separator.key-value.vue
 //          ^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //          ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//           ^^^^^^^ meta.interpolation.vue source.js.embedded.vue variable.other.readwrite.js
+//           ^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue variable.other.readwrite.js
 //                  ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 
@@ -71,19 +71,19 @@
 //       ^ meta.directive.vue punctuation.separator.key-value.vue
 //        ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//         ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue
+//         ^^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue
 //         ^^^^ variable.other.readwrite.js
 //              ^^ keyword.operator.js
 //                 ^^^^^ variable.other.readwrite.js
 //                      ^ string.quoted.double.vue punctuation.definition.string.end.vue
 //                       ^ punctuation.definition.tag.end.html
-//                         ^^^^^^^^^^^^^^^ meta.interpolation.vue
-//                         ^^ punctuation.section.interpolation.begin.html
+//                         ^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//                         ^^ punctuation.section.embedded.begin.html
 //                           ^^^^^^^^^^^ source.js.embedded.vue
 //                            ^^^^ variable.other.readwrite.js
 //                                ^ punctuation.accessor.js
 //                                 ^^^^ meta.property.object.js
-//                                      ^^ punctuation.section.interpolation.end.html
+//                                      ^^ punctuation.section.embedded.end.html
 //                                         ^^^^^ meta.tag
 
 
@@ -101,7 +101,7 @@
 //             ^ meta.directive.vue punctuation.separator.key-value.vue
 //              ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //              ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//               ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//               ^^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                            ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div @event="doSomething()"></div>
@@ -110,7 +110,7 @@
 //         ^ meta.directive.vue punctuation.separator.key-value.vue
 //          ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //          ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//           ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//           ^^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                        ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 
@@ -124,27 +124,27 @@
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^^^^ meta.directive.vue keyword.other.directive.vue
 //       ^ meta.directive.vue punctuation.separator.vue
-//        ^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
-//        ^ punctuation.section.interpolation.begin.vue
+//        ^^^^^^^^^^^ meta.directive.parameter.vue meta.embedded.expression.vue
+//        ^ punctuation.section.embedded.begin.vue
 //         ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
-//                  ^ punctuation.section.interpolation.end.vue
+//                  ^ punctuation.section.embedded.end.vue
 //                   ^ meta.directive.vue punctuation.separator.key-value.vue
 //                    ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                    ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                     ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                     ^^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                                  ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 <div @[eventName]="doSomething()"></div>
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //   ^ meta.directive.vue keyword.other.directive.vue
-//    ^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
-//    ^ punctuation.section.interpolation.begin.vue
+//    ^^^^^^^^^^^ meta.directive.parameter.vue meta.embedded.expression.vue
+//    ^ punctuation.section.embedded.begin.vue
 //     ^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
-//              ^ punctuation.section.interpolation.end.vue
+//              ^ punctuation.section.embedded.end.vue
 //               ^ meta.directive.vue punctuation.separator.key-value.vue
 //                ^^^^^^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                 ^^^^^^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                 ^^^^^^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                              ^ meta.string.vue string.quoted.double.vue punctuation.definition.string.end.vue
 
 
@@ -165,7 +165,7 @@
 //                ^ meta.directive.vue punctuation.separator.key-value.vue
 //                 ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                 ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                  ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                  ^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                          ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!-- the click event's propagation will be stopped -->
@@ -178,7 +178,7 @@
 //            ^ meta.directive.vue punctuation.separator.key-value.vue
 //             ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //             ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//              ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//              ^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                      ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!-- modifiers can be chained -->
@@ -193,7 +193,7 @@
 //                    ^ meta.directive.vue punctuation.separator.key-value.vue
 //                     ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                     ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                      ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                      ^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                              ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <a v-on:click:outside.prevent="doThis()"></a>
@@ -207,7 +207,7 @@
 //                           ^ meta.directive.vue punctuation.separator.key-value.vue
 //                            ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                            ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                             ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                             ^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                                     ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <a @click:outside.prevent="doThat()"></a>
@@ -220,7 +220,7 @@
 //                       ^ meta.directive.vue punctuation.separator.key-value.vue
 //                        ^^^^^^^^^^ meta.directive.value.vue meta.string.vue
 //                        ^ string.quoted.double.vue punctuation.definition.string.begin.vue
-//                         ^^^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.function-call
+//                         ^^^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.function-call
 //                                 ^ string.quoted.double.vue punctuation.definition.string.end.vue
 
 <!--
@@ -231,17 +231,17 @@
     v-bind:[styles["name"]]='{
 //  ^^^^^^ meta.directive.vue keyword.other.directive.vue
 //        ^ meta.directive.vue punctuation.separator.vue
-//         ^^^^^^^^^^^^^^^^ meta.directive.parameter.vue meta.interpolation.vue
-//         ^ punctuation.section.interpolation.begin.vue
+//         ^^^^^^^^^^^^^^^^ meta.directive.parameter.vue meta.embedded.expression.vue
+//         ^ punctuation.section.embedded.begin.vue
 //          ^^^^^^ variable.other.readwrite.js
 //                ^^^^^^^^ meta.brackets.js
 //                ^ punctuation.section.brackets.begin.js
 //                 ^^^^^^ meta.string.js string.quoted.double.js
 //                       ^ punctuation.section.brackets.end.js
-//                        ^ punctuation.section.interpolation.end.vue
+//                        ^ punctuation.section.embedded.end.vue
 //                         ^ meta.directive.vue punctuation.separator.key-value.vue
 //                          ^ meta.directive.value.vue meta.string.vue string.quoted.single.vue punctuation.definition.string.begin.vue
-//                           ^^ meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//                           ^^ meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue meta.mapping.js
         backgroundColor: active ? "green" : "red",
 //                              ^ keyword.operator.ternary.js
 //                                ^^^^^^^ meta.string.js string.quoted.double.js
@@ -256,7 +256,7 @@
 //                                            ^^^^^^^^^^ meta.string meta.interpolation.js - string
 //                                                      ^^^^ meta.string string.quoted.other.js
     }'>
-//^^^ meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping.js
+//^^^ meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue meta.mapping.js
 //   ^ meta.directive.value.vue meta.string.vue string.quoted.single.vue punctuation.definition.string.end.vue
 
     <!--
@@ -266,27 +266,27 @@
     <p v-attrib="{'key': 'value'}">
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue meta.mapping
-//                               ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue meta.mapping
+//                               ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                                ^ meta.tag - meta.directive
 //                                 ^ - meta.tag
 
     <p v-attrib="i = 0">
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
     <p v-attrib='i = 0'>
 //  ^^^ meta.tag - meta.directive
 //     ^^^^^^^^^ meta.tag meta.directive.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                    ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                     ^ meta.tag - meta.directive
 //                      ^ - meta.tag
 
@@ -296,9 +296,9 @@
 //            ^ meta.tag meta.directive.vue punctuation.separator.vue
 //             ^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
 //                  ^ meta.tag meta.directive.vue punctuation.separator.key-value.vue
-//                   ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//                    ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                               ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//                   ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//                    ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                               ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                                ^ meta.tag - meta.directive
 //                                 ^ - meta.tag
 
@@ -310,9 +310,9 @@
 //                  ^ meta.tag meta.directive.modifiers.vue punctuation.separator.vue
 //                   ^^^^^^^^ meta.tag meta.directive.modifiers.vue storage.modifier.vue
 //                           ^ meta.tag meta.directive.vue punctuation.separator.key-value.vue
-//                            ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//                             ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                                        ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//                            ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//                             ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                                        ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                                         ^ meta.tag - meta.directive
 //                                          ^ - meta.tag
 
@@ -322,9 +322,9 @@
 //            ^ meta.tag meta.directive.modifiers.vue punctuation.separator.vue
 //             ^^^^^^^^ meta.tag meta.directive.modifiers.vue storage.modifier.vue
 //                     ^ meta.tag meta.directive.vue punctuation.separator.key-value.vue
-//                      ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//                       ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                                  ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//                      ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//                       ^^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                                  ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                                   ^ meta.tag - meta.directive
 //                                    ^ - meta.tag
 
@@ -332,9 +332,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
@@ -342,9 +342,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                       ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                        ^ meta.tag - meta.directive
 //                         ^ - meta.tag
 
@@ -352,9 +352,9 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 
@@ -362,26 +362,26 @@
 //  ^^^ meta.tag - meta.directive
 //     ^ meta.tag meta.directive.vue keyword.other.directive.vue - meta.string
 //      ^^^^^^^ meta.tag meta.directive.parameter.vue entity.other.attribute-name.vue - meta.string
-//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
-//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.interpolation.vue source.js.embedded.vue
-//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.interpolation
+//              ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
+//               ^^^^^^^^^^ meta.tag meta.directive.value.vue meta.string.vue meta.embedded.expression.vue source.js.embedded.vue
+//                         ^ meta.tag meta.directive.value.vue meta.string.vue - meta.embedded.expression
 //                          ^ meta.tag - meta.directive
 //                           ^ - meta.tag
 
     <template #[`content-${variable}`]>
 //            ^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
-//             ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//              ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
-//                                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//             ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue punctuation.section.embedded.begin.vue - source.js.embedded
+//              ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue source.js.embedded.vue
+//                                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue punctuation.section.embedded.end.vue - source.js.embedded
 //                                    ^ meta.tag.template.begin.html - meta.directive
 //                                     ^ - meta.tag
 
     <template v-slot:[`content-${variable}`] >
 //            ^^^^^^ meta.tag.template.begin.html meta.directive.vue keyword.other.directive.vue
 //                  ^ meta.tag.template.begin.html meta.directive.vue punctuation.separator.vue
-//                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.begin.vue - source.js.embedded
-//                    ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue source.js.embedded.vue
-//                                         ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.interpolation.vue punctuation.section.interpolation.end.vue - source.js.embedded
+//                   ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue punctuation.section.embedded.begin.vue - source.js.embedded
+//                    ^^^^^^^^^^^^^^^^^^^^^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue source.js.embedded.vue
+//                                         ^ meta.tag.template.begin.html meta.directive.parameter.vue meta.embedded.expression.vue punctuation.section.embedded.end.vue - source.js.embedded
 //                                          ^ meta.tag.template.begin.html meta.directive.vue
 //                                           ^ meta.tag.template.begin.html - meta.directive
 //                                            ^ - meta.tag

--- a/tests/syntax_test_mustage.vue
+++ b/tests/syntax_test_mustage.vue
@@ -10,16 +10,16 @@
      -->
 
     <h1> {{ foo.text }} </h1>
-//       ^^^^^^^^^^^^^^ meta.interpolation.vue
-//       ^^ punctuation.section.interpolation.begin.html
+//       ^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//       ^^ punctuation.section.embedded.begin.html
 //         ^^^^^^^^^^ source.js.embedded.vue
-//                   ^^ punctuation.section.interpolation.end.html
+//                   ^^ punctuation.section.embedded.end.html
 
     <p {{foo.attrib}}>
-//     ^^^^^^^^^^^^^^ meta.interpolation.vue
-//     ^^ punctuation.section.interpolation.begin.html
+//     ^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//     ^^ punctuation.section.embedded.begin.html
 //       ^^^^^^^^^^ source.js.embedded.vue
-//                 ^^ punctuation.section.interpolation.end.html
+//                 ^^ punctuation.section.embedded.end.html
 
     <!--
     Mustache tags may only contain expressions!
@@ -28,17 +28,17 @@
     -->
 
     {{ number + 1 }}
-//  ^^^^^^^^^^^^^^^^ meta.interpolation.vue
-//  ^^ punctuation.section.interpolation.begin.html
+//  ^^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//  ^^ punctuation.section.embedded.begin.html
 //    ^^^^^^^^^^^^ source.js.embedded.vue
 //     ^^^^^^ variable.other.readwrite.js
 //            ^ keyword.operator.arithmetic.js
 //              ^ meta.number.integer.decimal.js constant.numeric.value.js
-//                ^^ punctuation.section.interpolation.end.html
+//                ^^ punctuation.section.embedded.end.html
 
     {{ ok ? 'YES' : 'NO' }}
-//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
-//  ^^ punctuation.section.interpolation.begin.html
+//  ^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//  ^^ punctuation.section.embedded.begin.html
 //    ^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
 //     ^^ variable.other.readwrite.js
 //        ^ keyword.operator.ternary.js
@@ -49,11 +49,11 @@
 //                  ^^^^ meta.string.js string.quoted.single.js
 //                  ^ punctuation.definition.string.begin.js
 //                     ^ punctuation.definition.string.end.js
-//                       ^^ punctuation.section.interpolation.end.html
+//                       ^^ punctuation.section.embedded.end.html
 
     {{ message.split('').reverse().join('') }}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
-//  ^^ punctuation.section.interpolation.begin.html
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//  ^^ punctuation.section.embedded.begin.html
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
 //     ^^^^^^^ variable.other.readwrite.js
 //            ^ punctuation.accessor.js
@@ -77,30 +77,30 @@
 //                                      ^ punctuation.definition.string.begin.js
 //                                       ^ punctuation.definition.string.end.js
 //                                        ^ punctuation.section.group.end.js
-//                                          ^^ punctuation.section.interpolation.end.html
+//                                          ^^ punctuation.section.embedded.end.html
 
     <div :id="`list-${id}`"></div>
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.tag
 //           ^^^^^^^^^^^^^ meta.string.vue
-//           ^ string.quoted.double.vue punctuation.definition.string.begin.vue - meta.interpolation
-//            ^^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string string
-//                  ^^^^^ meta.interpolation.vue source.js.embedded.vue meta.string meta.interpolation.js
-//                       ^ meta.interpolation.vue source.js.embedded.vue meta.string string
-//                        ^ string.quoted.double.vue punctuation.definition.string.end.vue - meta.interpolation
+//           ^ string.quoted.double.vue punctuation.definition.string.begin.vue - meta.embedded.expression
+//            ^^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.string string
+//                  ^^^^^ meta.embedded.expression.vue source.js.embedded.vue meta.string meta.interpolation.js
+//                       ^ meta.embedded.expression.vue source.js.embedded.vue meta.string string
+//                        ^ string.quoted.double.vue punctuation.definition.string.end.vue - meta.embedded.expression
 
     <!-- this is a statement, not an expression: -->
     {{ var a = 1 }}
-//  ^^^^^^^^^^^^^^^ meta.interpolation.vue
-//  ^^ punctuation.section.interpolation.begin.html
+//  ^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//  ^^ punctuation.section.embedded.begin.html
 //    ^^^^^^^^^^^ source.js.embedded.vue
-//               ^^ punctuation.section.interpolation.end.html
+//               ^^ punctuation.section.embedded.end.html
 
     <!-- flow control won't work either, use ternary expressions -->
     {{ if (ok) { return message } }}
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.vue
-//  ^^ punctuation.section.interpolation.begin.html
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.embedded.expression.vue
+//  ^^ punctuation.section.embedded.begin.html
 //    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.js.embedded.vue
-//                                ^^ punctuation.section.interpolation.end.html
+//                                ^^ punctuation.section.embedded.end.html
 
 
     <!--
@@ -112,13 +112,13 @@
      -->
 
     <p attrib="{{ foo.value }}" >
-//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
+//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.embedded.expression
 
     <p attrib='{{ foo.value }}' >
-//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.interpolation
+//            ^^^^^^^^^^^^^^^^^ meta.tag meta.attribute-with-value.html meta.string.html - meta.embedded.expression
 
     <p attrib={{ foo.value }} >
-//            ^^ meta.tag meta.attribute-with-value.html meta.string.html string.unquoted.html - meta.interpolation
+//            ^^ meta.tag meta.attribute-with-value.html meta.string.html string.unquoted.html - meta.embedded.expression
 //               ^^^^^^^^^ meta.attribute-with-value.html entity.other.attribute-name.html
 //                         ^^ meta.attribute-with-value.html entity.other.attribute-name.html
 
@@ -127,12 +127,12 @@
 //  ^^^ punctuation.definition.tag.begin.html
 //     ^^^^^ keyword.declaration.cdata.html
 //          ^ punctuation.definition.tag.begin.html
-//           ^^^^^^^^ string.unquoted.cdata.html - meta.interpolation
-//                   ^^^^^^^^^^^^^^^^ meta.interpolation.vue - string
-//                   ^^ punctuation.section.interpolation.begin.html
+//           ^^^^^^^^ string.unquoted.cdata.html - meta.embedded.expression
+//                   ^^^^^^^^^^^^^^^^ meta.embedded.expression.vue - string
+//                   ^^ punctuation.section.embedded.begin.html
 //                     ^^^^^^^^^^^^ source.js.embedded.vue variable.other.readwrite.js
-//                                 ^^ punctuation.section.interpolation.end.html
-//                                   ^^^^^^^^^ string.unquoted.cdata.html - meta.interpolation
+//                                 ^^ punctuation.section.embedded.end.html
+//                                   ^^^^^^^^^ string.unquoted.cdata.html - meta.embedded.expression
 //                                            ^^^ punctuation.definition.tag.end.html
 
 </html>


### PR DESCRIPTION
This PR modifies mustache tag scopes to align with majority of template
languages, which already use `meta.embedded` or `meta.embedded.expression`.

Motivation is a common scope for embedded template code.
Various template languages support both, control flow like statements
and string interpolations while not always being able to reliably distinguish
both syntax-wise.

Another aspect is embedded languages (e.g. JavaScript) also supporting native
string interpolation. Hence a distinction between embedded template code and
such native interpolations seems useful.

### Overview

At the time of writing...
Language       | statement blocks                    | expressions/interpolations
---            | ---                                 | ---
ASP            | `<% meta.embedded %>`                 |   `<%= meta.embedded %>`
Astro          | `n.v.`                                |   `{ meta.interpolation }`
Blade          | `@meta.embedded`                      |   `{{ meta.interpolation }}`
ERB            | `<% meta.embedded %>`                 |   `<%- meta.embedded %>`
Go Templates   | `{{ if meta.interpolation }}`         |   `{{ meta.interpolation }}`
Handlebars     | `{# meta.embedded}, {/meta.embedded}` |   `{{ meta.embedded }}`
Jinja2         | `{% meta.embedded.statement %}`       |   `{{ meta.embedded.expression }}`
JSP            | `<% meta.embedded.scriptlet %>`       |   `<%= meta.embedded.expression %>`
Liquid         | `{% meta.embedded %}`                 |   `{{ meta.interpolation }}`
Mustache       | `n.v.`                                |   `{{ meta.embedded.expression }}`
Ngx            | `@meta.embedded.statement`            |   `{{ meta.embedded.expression }}`
PHP            | `<? meta.embedded.statement ?>`       |   `<?= meta.embedded.expression ?>`
Svelte         | `{# meta.embedded}, {/meta.embedded}` |   `{{ meta.embedded }}`
Twig           | `{% meta.embedded.statement %}`       |   `{{ meta.embedded.expression }}`
Vue            | `n.v.`                                |   `{{ meta.embedded.expression }}`
